### PR TITLE
修复移动端分享页面过长 修复复制直链界面无法Ctrl+A

### DIFF
--- a/src/component/FileManager/Explorer.js
+++ b/src/component/FileManager/Explorer.js
@@ -31,7 +31,7 @@ import {
     Paper,
     Button
 } from "@material-ui/core";
-import { GlobalHotKeys } from "react-hotkeys";
+import { GlobalHotKeys,  configure } from "react-hotkeys";
 import TableSortLabel from "@material-ui/core/TableSortLabel";
 
 const styles = theme => ({
@@ -203,6 +203,10 @@ class ExplorerCompoment extends Component {
                 }
             }
         };
+
+        configure({
+            ignoreTags: ['input', 'select', 'textarea'],
+        })
     }
 
     contextMenu = e => {

--- a/src/component/Share/SharedFile.js
+++ b/src/component/Share/SharedFile.js
@@ -16,6 +16,8 @@ import API from "../../middleware/Api";
 import { withRouter } from "react-router-dom";
 import Creator from "./Creator";
 import pathHelper from "../../untils/page";
+let vh = window.innerHeight;
+document.documentElement.style.setProperty('--vh', `${vh}px`);
 const styles = theme => ({
     layout: {
         width: "auto",
@@ -64,7 +66,7 @@ const styles = theme => ({
         borderRadius: 12,
         boxShadow: "0 8px 16px rgba(29,39,55,.25)",
         [theme.breakpoints.down("sm")]: {
-            height: "calc(100vh - 56px)",
+            height: "calc(var(--vh, 100vh) - 56px)",
             borderRadius: 0,
             maxWidth: 1000
         },


### PR DESCRIPTION
# 修改前:  
<a href="https://ibb.co/kDD54hX"><img src="https://i.ibb.co/fNNqkCH/20200422-124950.jpg" alt="20200422-124950" border="0"></a>

# 修改后:  
<a href="https://ibb.co/RzcdMKB"><img src="https://i.ibb.co/zGZDLg7/20200422-125014.jpg" alt="20200422-125014" border="0"></a>

可以看到, 原先因为获取到的屏幕高度(100vh)包含地址栏, 页面高度突破了一个屏幕, 显示不全.  
修改后地址栏不再算作屏幕高度的一部分, 