### PR TITLE
Fix: 修复Redux Devtool bug; 添加Redux init action 测试

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,13 +13,11 @@ const Admin = React.lazy(() => import("./Admin"));
 
 serviceWorker.register();
 
-const middlewares = [thunk]
-// TODO: 仅在dev模式下添加devtools
-const store = createStore(cloureveApp, 
-  compose(
-    applyMiddleware(...middlewares),
-    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
-  ));
+let reduxEnhance = applyMiddleware(thunk)
+if (process.env.NODE_ENV === 'development' && window.__REDUX_DEVTOOLS_EXTENSION__) {
+  reduxEnhance = compose(reduxEnhance, window.__REDUX_DEVTOOLS_EXTENSION__())
+}
+const store = createStore(cloureveApp, reduxEnhance);
 UpdateSiteConfig(store);
 
 ReactDOM.render(

--- a/src/reducers/index.test.js
+++ b/src/reducers/index.test.js
@@ -30,8 +30,12 @@ const mockStore = configureMockStore(middlewares)
 
 describe('index reducer', () => {
   it('should return the initial state', () => {
-    expect(cloudreveApp(undefined, { type: '@@INIT'})).toEqual(initState)
-  })
+      expect(cloudreveApp(undefined, { type: '@@INIT'})).toEqual(initState)
+    })
+
+    it('should handle redux init', () => {
+      expect(cloudreveApp(undefined, { type: '@@redux/INIT'})).toEqual(initState)
+    })
 
   it('should handle DRAWER_TOGGLE', () => {
     const openAction = drawerToggleAction(true)


### PR DESCRIPTION
Fix https://github.com/cloudreve/frontend/issues/25
`window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()`
会返回undefined，我加了个 `compose` 所以会出现报错。
另外加了一个判断，只在`NODE_ENV=development` 下添加devtools extension