### PR TITLE
feat: add background audio player

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -30,6 +30,8 @@ import ResetForm from "./component/Login/ResetForm";
 import Reset from "./component/Login/Reset";
 import PageLoading from "./component/Placeholder/PageLoading";
 import CodeViewer from "./component/Viewer/Code";
+import MusicPlayer from "./component/FileManager/MusicPlayer";
+
 const PDFViewer = React.lazy(() =>
     import(/* webpackChunkName: "pdf" */ "./component/Viewer/PDF")
 );
@@ -207,6 +209,7 @@ export default function App() {
                             </Route>
                         </Switch>
                     </main>
+                    <MusicPlayer/>
                 </div>
             </ThemeProvider>
         </React.Fragment>

--- a/src/actions/explorer.js
+++ b/src/actions/explorer.js
@@ -4,9 +4,7 @@ import Auth from "../middleware/Auth";
 import {
     changeContextMenu,
     openLoadingDialog,
-    openMusicDialog,
     showImgPreivew,
-    showAudioPreivew,
     toggleSnackbar,
     showAudioPreview,
 } from "./index";

--- a/src/actions/explorer.js
+++ b/src/actions/explorer.js
@@ -6,7 +6,9 @@ import {
     openLoadingDialog,
     openMusicDialog,
     showImgPreivew,
+    showAudioPreivew,
     toggleSnackbar,
+    showAudioPreview,
 } from "./index";
 import { isPreviewable } from "../config";
 import { push } from "connected-react-router";
@@ -97,7 +99,11 @@ export const openPreview = () => {
                 );
                 return;
             case "audio":
-                dispatch(openMusicDialog());
+                //if (isShare) {
+                //    dispatch(openMusicDialog());
+                //}else{
+                    dispatch(showAudioPreview(selected[0]));
+                //}
                 return;
             case "video":
                 if (isShare) {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -247,6 +247,29 @@ export const showImgPreivew = (first) => {
     };
 };
 
+export const showAudioPreview = (first) => {
+    return {
+        type: "SHOW_AUDIO_PREVIEW",
+        first: first,
+    };
+};
+
+export const audioPreviewSetIsOpen = (isOpen) => {
+    return {
+        type: "AUDIO_PREVIEW_SET_IS_OPEN",
+        isOpen,
+    };
+};
+
+export const audioPreviewSetPlaying = (playingName,paused) => {
+    return {
+        type: "AUDIO_PREVIEW_SET_PLAYING",
+        playingName,//the playing content name
+        paused,
+    };
+};
+
+
 export const refreshStorage = () => {
     return {
         type: "REFRESH_STORAGE",

--- a/src/component/FileManager/Explorer.js
+++ b/src/component/FileManager/Explorer.js
@@ -31,6 +31,7 @@ import { isMac } from "../../utils";
 import pathHelper from "../../utils/page";
 import ContextMenu from "./ContextMenu";
 import ImgPreivew from "./ImgPreview";
+import MusicPlayer from "./MusicPlayer";
 import ObjectIcon from "./ObjectIcon";
 
 const styles = (theme) => ({
@@ -443,6 +444,7 @@ class ExplorerCompoment extends Component {
                 <GlobalHotKeys handlers={this.handlers} keyMap={this.keyMap} />
                 <ContextMenu share={this.props.share} />
                 <ImgPreivew />
+                <MusicPlayer />
                 {this.props.navigatorError && (
                     <Paper elevation={1} className={classes.errorBox}>
                         <Typography variant="h5" component="h3">

--- a/src/component/FileManager/Explorer.js
+++ b/src/component/FileManager/Explorer.js
@@ -31,7 +31,6 @@ import { isMac } from "../../utils";
 import pathHelper from "../../utils/page";
 import ContextMenu from "./ContextMenu";
 import ImgPreivew from "./ImgPreview";
-import MusicPlayer from "./MusicPlayer";
 import ObjectIcon from "./ObjectIcon";
 
 const styles = (theme) => ({
@@ -444,7 +443,6 @@ class ExplorerCompoment extends Component {
                 <GlobalHotKeys handlers={this.handlers} keyMap={this.keyMap} />
                 <ContextMenu share={this.props.share} />
                 <ImgPreivew />
-                <MusicPlayer />
                 {this.props.navigatorError && (
                     <Paper elevation={1} className={classes.errorBox}>
                         <Typography variant="h5" component="h3">

--- a/src/component/FileManager/MusicPlayer.js
+++ b/src/component/FileManager/MusicPlayer.js
@@ -33,7 +33,10 @@ const styles = (theme) => ({
         position: 'relative',
         overflow: 'auto',
         maxHeight: 300,
-    }
+    },
+    slider_root:{
+        "vertical-align": "middle",
+    },
 });
 
 const mapStateToProps = (state) => {
@@ -330,9 +333,9 @@ class MusicPlayerComponent extends Component {
                         src={items[currentIndex]?.src}
                         />
                     <div style={{"padding-top":8}}></div>
-                    <Grid container spacing={2}>
+                    <Grid container spacing={2} alignItems="center">
                         <Grid item xs>
-                        <Slider 
+                        <Slider classes={{"root":classes.slider_root}}
                             value={this.state.currentTime}
                             onChange={this.handleProgress}
                             step={1}

--- a/src/component/FileManager/MusicPlayer.js
+++ b/src/component/FileManager/MusicPlayer.js
@@ -1,0 +1,391 @@
+import {
+    Button, Dialog,
+    DialogActions,
+    DialogContent, DialogTitle, withStyles
+} from "@material-ui/core";
+import IconButton from '@material-ui/core/IconButton';
+import {Slider,List,Grid} from '@material-ui/core';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import MusicNote from '@material-ui/icons/MusicNote';
+import PlayArrow from '@material-ui/icons/PlayArrow';
+import PlayNext from '@material-ui/icons/SkipNext';
+import PlayPrev from '@material-ui/icons/SkipPrevious';
+import Pause from '@material-ui/icons/Pause';
+import {Repeat, RepeatOne, Shuffle} from '@material-ui/icons';
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { withRouter } from "react-router";
+import { showAudioPreview ,audioPreviewSetIsOpen, audioPreviewSetPlaying} from "../../actions/index";
+import { audioPreviewSuffix } from "../../config";
+import { baseURL } from "../../middleware/Api";
+import * as explorer from "../../redux/explorer/reducer";
+import pathHelper from "../../utils/page";
+
+
+
+const styles = (theme) => ({  
+    list: {
+        //maxWidth: 360,
+        backgroundColor: theme.palette.background.paper,
+        position: 'relative',
+        overflow: 'auto',
+        maxHeight: 300,
+    }
+});
+
+const mapStateToProps = (state) => {
+    return {
+        first: state.explorer.audioPreview.first,
+        other: state.explorer.audioPreview.other,
+        isOpen:state.explorer.audioPreview.isOpen,
+        playingName:state.explorer.audioPreview.playingName,
+    };
+};
+
+const mapDispatchToProps = (dispatch) => {
+    return {
+        showAudioPreview: (first) => {
+            dispatch(showAudioPreview(first));
+        },
+        audioPreviewSetIsOpen: (first) => {
+            dispatch(audioPreviewSetIsOpen(first));
+        },
+        audioPreviewSetPlaying: (playingName,paused) => {
+            dispatch(audioPreviewSetPlaying(playingName,paused));
+        },
+    };
+};
+
+class MusicPlayerComponent extends Component {
+    state = {
+        items: [],
+        currentIndex: 0,
+        //isOpen: false,
+        //isPlay:false,
+        currentTime:0,
+        duration:0,
+        progressText:'00:00/00:00',
+        looptype:0,
+    };
+    myAudioRef = React.createRef();  
+
+    UNSAFE_componentWillReceiveProps = (nextProps) => {
+        const items = [];
+        let firstOne = 0;
+        if (nextProps.first.id !== "") {
+            if (
+                pathHelper.isSharePage(this.props.location.pathname) &&
+                !nextProps.first.path
+            ) {
+                const newItem = {
+                    intro: nextProps.first.name,
+                    src: baseURL + "/share/preview/" + nextProps.first.key,
+                };
+                firstOne = 0;
+                items.push(newItem);
+                this.setState({
+                    currentIndex: firstOne,
+                    items: items,
+                    //isOpen: true,
+                });
+                this.props.audioPreviewSetIsOpen(true);
+                return;
+            }
+            // eslint-disable-next-line
+            nextProps.other.map((value) => {
+                const fileType = value.name.split(".").pop().toLowerCase();
+                if (audioPreviewSuffix.indexOf(fileType) !== -1) {
+                    let src = "";
+                    if (pathHelper.isSharePage(this.props.location.pathname)) {
+                        src = baseURL + "/share/preview/" + value.key;
+                        src =
+                            src +
+                            "?path=" +
+                            encodeURIComponent(
+                                value.path === "/"
+                                    ? value.path + value.name
+                                    : value.path + "/" + value.name
+                            );
+                    } else {
+                        src = baseURL + "/file/preview/" + value.id;
+                    }
+                    const newItem = {
+                        intro: value.name,
+                        src: src,
+                    };
+                    if (
+                        value.path === nextProps.first.path &&
+                        value.name === nextProps.first.name
+                    ) {
+                        firstOne = items.length;
+                    }
+                    items.push(newItem);
+                }
+            });
+            this.setState({
+                currentIndex: firstOne,
+                items: items,
+                //isOpen: true,
+            });
+            this.props.audioPreviewSetIsOpen(true);
+            this.props.showAudioPreview(explorer.initState.audioPreview.first);
+        }        
+    };
+
+    handleItemClick = (currentIndex) => () => {
+        this.setState({
+            currentIndex: currentIndex,
+        });
+    };
+    
+
+    handleClose = () => {
+        /*this.setState({
+            isOpen: false,
+        });*/
+        this.pause();
+        this.props.audioPreviewSetPlaying(null,false);
+        this.props.audioPreviewSetIsOpen(false);
+    };
+    backgroundPlay = () => {        
+        this.props.audioPreviewSetIsOpen(false);
+    };
+
+    componentDidMount() {
+        if(this.myAudioRef.current){
+            this.bindEvents(this.myAudioRef.current);
+        }
+    }
+    componentDidUpdate() {
+        if(this.myAudioRef.current){
+            this.bindEvents(this.myAudioRef.current);
+        }
+    }    
+    componentWillUnmount() {
+        this.unbindEvents(this.myAudioRef.current)
+    }
+
+    bindEvents=(ele)=>{
+        if(ele){
+            ele.addEventListener('canplay', this.readyPlay)
+            ele.addEventListener('ended', this.loopnext)
+            ele.addEventListener('timeupdate', this.timeUpdate)
+        }
+    };
+
+    unbindEvents=(ele)=> {
+        if(ele){
+            ele.removeEventListener('canplay', this.readyPlay)
+            ele.removeEventListener('ended', this.loopnext)
+            ele.removeEventListener('timeupdate', this.timeUpdate)
+        }
+    };
+
+    readyPlay = () => {
+        this.play();
+    };
+
+    formatTime = s => {
+        if(isNaN(s))return "00:00";
+        const minute = Math.floor(s / 60);
+        const second = Math.floor(s % 60);
+        return `${minute}`.padStart(2,'0')+':'+`${second}`.padStart(2,'0');
+    }
+
+    timeUpdate = () => {
+        const currentTime=Math.floor(this.myAudioRef.current.currentTime);//this.myAudioRef.current.currentTime;//
+        this.setState({
+            currentTime: currentTime,
+            duration: this.myAudioRef.current.duration,
+            progressText: this.formatTime(currentTime)+'/'+this.formatTime(this.myAudioRef.current.duration)
+        });
+    }
+
+    play = () => {
+       this.myAudioRef.current.play();
+       /*this.setState({
+            isPlay: true
+        });*/
+        this.props.audioPreviewSetPlaying(this.state.items[this.state.currentIndex].intro,false);
+    };
+
+    pause = () => {
+        this.myAudioRef.current.pause()
+        /*this.setState({
+            isPlay: false
+        })*/
+        this.props.audioPreviewSetPlaying(this.state.items[this.state.currentIndex].intro,true);
+    };
+
+    playOrPaues = () => {
+        if (this.state.isPlay) {
+            this.pause()
+        } else {
+            this.play()
+        }
+    };
+    changeLoopType=()=>{
+        let lt=this.state.looptype+1;
+        if(lt>=3){
+            lt=0;
+        }
+        this.setState({
+            looptype: lt,
+        });
+    };
+    loopnext=()=>{
+        let index = this.state.currentIndex;
+        if(this.state.looptype==0){//all
+            index=index+1;
+            if (index >= this.state.items.length) {
+                index =  0;
+            }
+        }else if(this.state.looptype==1){//single
+            //index=index;
+            this.myAudioRef.current.currentTime=0;
+            this.play();
+        }else if(this.state.looptype==2){//random
+            if(this.state.items.length<=2){
+                index=index+1;
+                if (index >= this.state.items.length) {
+                    index =  0;
+                }
+            }else{
+                while(index==this.state.currentIndex){
+                    index=Math.floor(Math.random()*this.state.items.length);
+                }
+            }
+        }
+        this.setState({
+            currentIndex: index,
+        });
+    }
+
+    prev = () => {
+        let index = this.state.currentIndex - 1
+        if (index < 0) {
+            index = this.state.items.length - 1
+        }
+        this.setState({
+            currentIndex: index,
+        });
+    };
+    
+    next = () => {
+        let index = this.state.currentIndex + 1
+        if (index >= this.state.items.length) {
+            index =  0;
+        }
+        this.setState({
+            currentIndex: index,
+        });
+    };
+
+    handleProgress = (e, newValue) => {
+        this.myAudioRef.current.currentTime=newValue;
+    }
+      
+
+    render() {
+        const { currentIndex, items } = this.state;
+        const { isOpen } = this.props;
+        const { classes } = this.props;
+        return (            
+            <Dialog
+                open={isOpen}
+                onClose={this.backgroundPlay}
+                aria-labelledby="form-dialog-title"
+                maxWidth="xs"
+                fullWidth
+                keepMounted
+            >
+                <DialogTitle id="form-dialog-title">音频播放</DialogTitle>
+                <DialogContent>
+                    <List className={classes.list} dense>
+                        {items.map((value,idx) => {
+                            const labelId = `label-${value.intro}`;
+                            return (
+                                <ListItem key={value.src} dense button onClick={this.handleItemClick(idx)}
+                                    selected={idx==currentIndex}>
+                                    <ListItemIcon>
+                                        {
+                                            idx==currentIndex?(<PlayArrow/>):(<MusicNote/>)
+                                        }
+                                    </ListItemIcon>
+                                    <ListItemText id={labelId} primary={`${value.intro}`} />
+                                </ListItem>
+                            );
+                        })}
+                    </List>
+                    <audio ref={this.myAudioRef}                                 
+                        src={items[currentIndex]?.src}
+                        />
+                    <Grid container spacing={2}>
+                        <Grid item>
+                        </Grid>
+                        <Grid item xs>
+                        <Slider 
+                            value={this.state.currentTime}
+                            onChange={this.handleProgress}
+                            step={1}
+                            min={0}
+                            max={this.state.duration}
+                            aria-labelledby="continuous-slider" />
+                        </Grid>
+                        <Grid item>
+                            {this.state.progressText}
+                        </Grid>
+                    </Grid>
+                    <Grid container spacing={2} justifyContent="center" justify="center">
+                        <Grid item>
+                            <IconButton edge="end" aria-label="" onClick={this.changeLoopType}>
+                                {
+                                    this.state.looptype==0?(<Repeat/>):(this.state.looptype==1?(<RepeatOne/>):(<Shuffle />))
+                                }
+                            </IconButton>
+                        </Grid>
+                        <Grid item>
+                            <IconButton edge="end" aria-label="" onClick={this.prev}>
+                                <PlayPrev />
+                            </IconButton>
+                        </Grid>
+                        <Grid item>
+                            <IconButton edge="end" aria-label="" onClick={this.pause}>
+                                <Pause />
+                            </IconButton>
+                        </Grid>
+                        <Grid item>
+                            <IconButton edge="end" aria-label="" onClick={this.play}>
+                                <PlayArrow />
+                            </IconButton>
+                        </Grid>
+                        <Grid item>
+                            <IconButton edge="end" aria-label="" onClick={this.next}>
+                                <PlayNext />
+                            </IconButton>
+                        </Grid>                                
+                    </Grid>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={this.handleClose}>退出播放</Button>
+                    <Button onClick={this.backgroundPlay}>后台播放</Button>
+                </DialogActions>
+            </Dialog>
+            
+        );
+    }
+}
+
+MusicPlayerComponent.propTypes = {
+    classes: PropTypes.object.isRequired,
+};
+
+const MusicPlayer = connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(withStyles(styles)(withRouter(MusicPlayerComponent)));
+
+export default MusicPlayer;

--- a/src/component/FileManager/MusicPlayer.js
+++ b/src/component/FileManager/MusicPlayer.js
@@ -146,6 +146,9 @@ class MusicPlayerComponent extends Component {
         /*this.setState({
             isOpen: false,
         });*/
+        this.setState({
+            currentIndex: -1,
+        });
         this.pause();
         this.props.audioPreviewSetPlaying(null,false);
         this.props.audioPreviewSetIsOpen(false);
@@ -213,11 +216,13 @@ class MusicPlayerComponent extends Component {
     };
 
     pause = () => {
-        this.myAudioRef.current.pause()
+        if(this.myAudioRef.current){
+            this.myAudioRef.current.pause();
+        }
         /*this.setState({
             isPlay: false
         })*/
-        this.props.audioPreviewSetPlaying(this.state.items[this.state.currentIndex].intro,true);
+        this.props.audioPreviewSetPlaying(this.state.items[this.state.currentIndex]?.intro,true);
     };
 
     playOrPaues = () => {
@@ -245,8 +250,6 @@ class MusicPlayerComponent extends Component {
             }
         }else if(this.state.looptype==1){//single
             //index=index;
-            this.myAudioRef.current.currentTime=0;
-            this.play();
         }else if(this.state.looptype==2){//random
             if(this.state.items.length<=2){
                 index=index+1;
@@ -258,6 +261,10 @@ class MusicPlayerComponent extends Component {
                     index=Math.floor(Math.random()*this.state.items.length);
                 }
             }
+        }
+        if(this.state.currentIndex==index){
+            this.myAudioRef.current.currentTime=0;
+            this.play();
         }
         this.setState({
             currentIndex: index,
@@ -291,8 +298,7 @@ class MusicPlayerComponent extends Component {
 
     render() {
         const { currentIndex, items } = this.state;
-        const { isOpen } = this.props;
-        const { classes } = this.props;
+        const { isOpen,classes } = this.props;
         return (            
             <Dialog
                 open={isOpen}

--- a/src/component/FileManager/MusicPlayer.js
+++ b/src/component/FileManager/MusicPlayer.js
@@ -323,9 +323,8 @@ class MusicPlayerComponent extends Component {
                     <audio ref={this.myAudioRef}                                 
                         src={items[currentIndex]?.src}
                         />
+                    <div style={{"padding-top":8}}></div>
                     <Grid container spacing={2}>
-                        <Grid item>
-                        </Grid>
                         <Grid item xs>
                         <Slider 
                             value={this.state.currentTime}

--- a/src/component/Navbar/Navbar.js
+++ b/src/component/Navbar/Navbar.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import classNames from "classnames";
 import { connect } from "react-redux";
 import ShareIcon from "@material-ui/icons/Share";
+import MusicNote from "@material-ui/icons/MusicNote";
 import BackIcon from "@material-ui/icons/ArrowBack";
 import OpenIcon from "@material-ui/icons/OpenInNew";
 import DownloadIcon from "@material-ui/icons/CloudDownload";
@@ -31,6 +32,7 @@ import {
     openLoadingDialog,
     setSessionStatus,
     openPreview,
+    audioPreviewSetIsOpen,
 } from "../../actions";
 import {
     allowSharePreview,
@@ -87,6 +89,8 @@ const mapStateToProps = (state) => {
         subTitle: state.viewUpdate.subTitle,
         loadUploader: state.viewUpdate.loadUploader,
         isLogin: state.viewUpdate.isLogin,
+        audioPreviewPlayingName:state.explorer.audioPreview.playingName,
+        audioPreviewIsOpen:state.explorer.audioPreview.isOpen,
     };
 };
 
@@ -142,6 +146,9 @@ const mapDispatchToProps = (dispatch) => {
         },
         openPreview: () => {
             dispatch(openPreview());
+        },
+        audioPreviewOpen: () => {
+            dispatch(audioPreviewSetIsOpen(true));
         },
     };
 };
@@ -881,6 +888,20 @@ class NavbarCompoment extends Component {
                                     )}
                                 </div>
                             )}
+                        {this.props.selected.length <= 1 &&
+                            !(
+                                !this.props.isMultiple && this.props.withFile
+                            ) && this.props.audioPreviewPlayingName!=null && (
+                            <IconButton
+                                title="音乐"
+                                className={classes.sideButton}
+                                onClick={this.props.audioPreviewOpen}
+                                color={"inherit"}
+                            >
+                                <MusicNote fontSize={ "default"} />
+                            </IconButton>
+                        )}
+
                         {this.props.selected.length <= 1 &&
                             !(
                                 !this.props.isMultiple && this.props.withFile

--- a/src/config.js
+++ b/src/config.js
@@ -16,7 +16,7 @@ export const msDocPreviewSuffix = [
     "xlsx",
     "xls",
 ];
-export const audioPreviewSuffix = ["mp3", "ogg"];
+export const audioPreviewSuffix = ["mp3", "ogg","flac"];
 export const videoPreviewSuffix = ["mp4", "mkv", "webm"];
 export const pdfPreviewSuffix = ["pdf"];
 export const editSuffix = ["md", "txt"];

--- a/src/redux/explorer/reducer.ts
+++ b/src/redux/explorer/reducer.ts
@@ -25,6 +25,13 @@ export interface ExplorerState {
         first: CloudreveFile;
         other: [];
     };
+    audioPreview: {
+        first: CloudreveFile;
+        other: [];
+        playingName: any;
+        paused: boolean;
+        isOpen: boolean;
+    };
     keywords: string;
     fileSave: boolean;
     sideBarOpen: boolean;
@@ -62,6 +69,19 @@ export const initState: ExplorerState = {
             date: "",
         },
         other: [],
+    },
+    audioPreview: {
+        first: {
+            id: "",
+            name: "",
+            size: 0,
+            type: "file",
+            date: "",
+        },
+        other: [],
+        playingName: null,
+        paused: false,
+        isOpen: false,
     },
     keywords: "",
     fileSave: false,
@@ -150,6 +170,29 @@ const explorer = (
                 imgPreview: {
                     first: action.first,
                     other: state.fileList,
+                },
+            });
+        case "SHOW_AUDIO_PREVIEW":
+            return Object.assign({}, state, {
+                audioPreview: {
+                    ...state.audioPreview,
+                    first: action.first,
+                    other: state.fileList,
+                },
+            });
+        case "AUDIO_PREVIEW_SET_IS_OPEN":            
+            return Object.assign({}, state, {
+                audioPreview: {
+                    ...state.audioPreview,
+                    isOpen: action.isOpen,
+                },
+            });
+        case "AUDIO_PREVIEW_SET_PLAYING":
+            return Object.assign({}, state, {
+                audioPreview: {
+                    ...state.audioPreview,
+                    playingName: action.playingName,
+                    paused: action.paused,
                 },
             });
         case "SAVE_FILE":


### PR DESCRIPTION
Add a backgrond audio player.
Able to play all audio files in a folder in a loop or randomly.
Add an icon on the navbar to call it out when it's in background.
![background player](https://user-images.githubusercontent.com/5524046/141601174-221e832a-b5ae-4993-b1a3-335f3e72b235.PNG)
No backend  change needed.