### PR TITLE
feat: add thumbnail cache in pwa

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -668,6 +668,19 @@ module.exports = function(webpackEnv) {
             new RegExp(/^\/api/),
             new RegExp(/^\/custom/),
           ],
+          runtimeCaching: [
+            {
+                urlPattern: new RegExp(/.*\/thumb\/.*/i),
+                handler: 'StaleWhileRevalidate',
+                options: {
+                    cacheName: 'thumbnail-cache',
+                    expiration: {
+                        maxEntries: 100,
+                        maxAgeSeconds: 30 * 24 * 60 * 60,
+                    },
+                },
+            }
+          ]
         }),
       // TypeScript type checking
       useTypeScript &&


### PR DESCRIPTION
Now thumbnail of pictures and videos can be cached in pwa and updated in background.