### PR TITLE
Fix: Cards on MyShareComponent will not overlap and text will not be obscured when using medium screen device

### DIFF
--- a/src/component/Share/MyShare.js
+++ b/src/component/Share/MyShare.js
@@ -287,7 +287,7 @@ class MyShareCompoment extends Component {
                         </FormControl>
                     </Grid>
                 </Grid>
-                <Grid container spacing={24} className={classes.gird}>
+                <Grid container spacing={2} className={classes.gird}>
                     {this.state.shareList.length === 0 && (
                         <Nothing primary={t("share.noRecords")} />
                     )}
@@ -295,7 +295,8 @@ class MyShareCompoment extends Component {
                         <Grid
                             item
                             xs={12}
-                            sm={4}
+                            sm={6}
+                            md={4}
                             key={value.id}
                             className={classes.cardContainer}
                         >


### PR DESCRIPTION
When I use the iPad Pro 2021 (11-inch) vertical split preview to share the page, the text of the Card component is occluded, because the Grid Item still only occupies 1/3 of the width in md size. 

Three per column will cause the Card to display abnormally, and we can solve this problem with a simple modification.

![292225de083f14f0d8e6a7e90f8bec1](https://user-images.githubusercontent.com/51253685/167810824-bbd0273c-066f-49d8-b604-53f5a794814e.jpg)

Also, `spacing={24}` is invalid.