### PR TITLE
fix(修复pdf预览偶尔error): 替换pdf.worker.js的cdn服务商为staticfile.org

### DIFF
--- a/src/component/Viewer/PDF.js
+++ b/src/component/Viewer/PDF.js
@@ -11,7 +11,7 @@ import { toggleSnackbar } from "../../redux/explorer";
 import UseFileSubTitle from "../../hooks/fileSubtitle";
 import { useTranslation } from "react-i18next";
 
-pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
+pdfjs.GlobalWorkerOptions.workerSrc = `//cdn.staticfile.org/pdf.js/${pdfjs.version}/pdf.worker.js`;
 
 const useStyles = makeStyles((theme) => ({
     layout: {


### PR DESCRIPTION
修复默认pdf预览偶尔失败的问题