### PR TITLE
Feat: download the whole directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/react": "^16.9.35",
     "@types/react-dom": "^16.9.8",
     "@types/streamsaver": "^2.0.1",
+    "@types/wicg-file-system-access": "^2020.9.5",
     "@typescript-eslint/eslint-plugin": "^2.33.0",
     "@typescript-eslint/parser": "^2.33.0",
     "artplayer": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/wicg-file-system-access": "^2020.9.5",
     "@typescript-eslint/eslint-plugin": "^2.33.0",
     "@typescript-eslint/parser": "^2.33.0",
+    "ahooks": "^3.5.2",
     "artplayer": "^4.3.4",
     "axios": "^0.21.1",
     "babel-eslint": "10.0.3",

--- a/public/locales/en-US/application.json
+++ b/public/locales/en-US/application.json
@@ -161,7 +161,17 @@
     "serverBatchDownloadDescription": "Archive by the server and sent to the client for download on-the-fly.",
     "selectArchiveMethod": "Select archive method",
     "batchDownloadStarted": "Batch download has started, please do not close this tab",
-    "batchDownloadError": "Failed to archive: {{msg}}"
+    "batchDownloadError": "Failed to archive: {{msg}}",
+    "userDenied": "User denied.",
+    "directoryDownloadReplace": "Overwrite",
+    "directoryDownloadReplaceDescription": "{{num}} objects including {{duplicates}} will be overwritten.",
+    "directoryDownloadSkip": "Skip",
+    "directoryDownloadSkipDescription": "{{num}} objects including {{duplicates}} will be skipped.",
+    "selectDirectoryDuplicationMethod": "How to handle duplicate files?",
+    "directoryDownloadStarted": "Download started, please do not close this tab.",
+    "directoryDownloadFinished": "Download finished, no failed objects.",
+    "directoryDownloadFinishedWithError": "Download finished, {{failed}} object failed.",
+    "directoryDownloadPermissionError": "Permission denied, please allow read and write local files."
   },
   "modals": {
     "processing": "Processing...",
@@ -220,7 +230,15 @@
     "allowPreview": "Enable preview",
     "allowPreviewDescription": "Whether to allow preview of file content from the share link",
     "shareLink": "Share link",
-    "sendLink": "Send the link"
+    "sendLink": "Send the link",
+    "directoryDownloadReplaceNotifiction": "Overwrite {{name}}",
+    "directoryDownloadSkipNotifiction": "Skipped {{name}}",
+    "directoryDownloadTitle": "Download",
+    "directoryDownloadStarted": "Start downloading {{name}}",
+    "directoryDownloadFinished": "Download finished",
+    "directoryDownloadError": "Error: {{msg}}",
+    "directoryDownloadErrorNotification": "Error occurs while download {{name}}: {{msg}}",
+    "directoryDownloadAutoscroll": "Auto scroll"
   },
   "uploader": {
     "fileNotMatchError": "The selected file does not match the original file.",

--- a/public/locales/en-US/application.json
+++ b/public/locales/en-US/application.json
@@ -238,7 +238,8 @@
     "directoryDownloadFinished": "Download finished",
     "directoryDownloadError": "Error: {{msg}}",
     "directoryDownloadErrorNotification": "Error occurs while download {{name}}: {{msg}}",
-    "directoryDownloadAutoscroll": "Auto scroll"
+    "directoryDownloadAutoscroll": "Auto scroll",
+    "directoryDownloadCancelled": "Download cancelled"
   },
   "uploader": {
     "fileNotMatchError": "The selected file does not match the original file.",

--- a/public/locales/zh-CN/application.json
+++ b/public/locales/zh-CN/application.json
@@ -238,7 +238,8 @@
     "directoryDownloadFinished": "下载完成",
     "directoryDownloadError": "遇到错误：{{msg}}",
     "directoryDownloadErrorNotification": "下载 {{name}} 遇到错误：{{msg}}",
-    "directoryDownloadAutoscroll": "自动滚动"
+    "directoryDownloadAutoscroll": "自动滚动",
+    "directoryDownloadCancelled": "已取消下载"
   },
   "uploader": {
     "fileNotMatchError": "所选择文件与原始文件不符",

--- a/public/locales/zh-CN/application.json
+++ b/public/locales/zh-CN/application.json
@@ -169,7 +169,6 @@
     "directoryDownloadSkipDescription": "将会跳过 {{duplicates}} 等共 {{num}} 个对象。",
     "selectDirectoryDuplicationMethod": "重复对象处理方式",
     "directoryDownloadStarted": "下载已开始，请不要关闭此标签页",
-    "directoryDownloadError": "下载 {{name}} 遇到错误：{{msg}}",
     "directoryDownloadFinished": "下载完成，无失败对象",
     "directoryDownloadFinishedWithError": "下载完成, 失败 {{failed}} 个对象"
   },
@@ -232,7 +231,12 @@
     "shareLink": "分享链接",
     "sendLink": "发送链接",
     "directoryDownloadReplaceNotifiction": "已覆盖 {{name}}",
-    "directoryDownloadSkipNotifiction": "已跳过 {{name}}"
+    "directoryDownloadSkipNotifiction": "已跳过 {{name}}",
+    "directoryDownloadTitle": "下载",
+    "directoryDownloadStarted": "开始下载 {{name}}",
+    "directoryDownloadFinished": "下载完成",
+    "directoryDownloadError": "遇到错误：{{msg}}",
+    "directoryDownloadErrorNotification": "下载 {{name}} 遇到错误：{{msg}}"
   },
   "uploader": {
     "fileNotMatchError": "所选择文件与原始文件不符",
@@ -270,7 +274,7 @@
     "hideCompletedTooltip": "列表中不显示已完成、失败、被取消的任务",
     "hideCompleted": "隐藏已完成任务",
     "addTimeAscTooltip": "最先添加的任务排在最前",
-    "addTimeAsc":"最先添加靠前",
+    "addTimeAsc": "最先添加靠前",
     "addTimeDescTooltip": "最后添加的任务排在最前",
     "addTimeDesc": "最后添加靠前",
     "showInstantSpeedTooltip": "单个任务上传速度展示为瞬时速度",
@@ -303,7 +307,7 @@
   },
   "share": {
     "expireInXDays": "{{num}} 天后到期",
-    "expireInXHours":"{{num}} 小时后到期",
+    "expireInXHours": "{{num}} 小时后到期",
     "createdBy": "此分享由 <0>{{nick}}</0> 创建",
     "sharedBy": "<0>{{nick}}</0> 向您分享了 {{num}} 个文件",
     "statistics": "{{views}} 次浏览 • {{downloads}} 次下载 • {{time}}",
@@ -316,9 +320,9 @@
     "createdAtDesc": "创建日期由晚到早",
     "createdAtAsc": "创建日期由早到晚",
     "downloadsDesc": "下载次数由大到小",
-    "downloadsAsc":"下载次数由小到大",
-    "viewsDesc":"浏览次数由大到小",
-    "viewsAsc":"浏览次数由小到大",
+    "downloadsAsc": "下载次数由小到大",
+    "viewsDesc": "浏览次数由大到小",
+    "viewsAsc": "浏览次数由小到大",
     "noRecords": "没有分享记录.",
     "sourceNotFound": "[原始对象不存在]",
     "expired": "已失效",

--- a/public/locales/zh-CN/application.json
+++ b/public/locales/zh-CN/application.json
@@ -162,7 +162,15 @@
     "selectArchiveMethod": "选择打包下载方式",
     "batchDownloadStarted": "打包下载已开始，请不要关闭此标签页",
     "batchDownloadError": "打包遇到错误：{{msg}}",
-    "userDenied": "用户拒绝"
+    "userDenied": "用户拒绝",
+    "directoryDownloadReplace": "替换对象",
+    "directoryDownloadReplaceDescription": "将会替换 {{duplicates}} 等共 {{num}} 个对象。",
+    "directoryDownloadSkip": "跳过对象",
+    "directoryDownloadSkipDescription": "将会跳过 {{duplicates}} 等共 {{num}} 个对象。",
+    "selectDirectoryDuplicationMethod": "重复对象处理方式",
+    "directoryDownloadStarted": "下载已开始，请不要关闭此标签页",
+    "directoryDownloadError": "下载 {{name}} 遇到错误：{{msg}}",
+    "directoryDownloadFinished": "下载完成"
   },
   "modals": {
     "processing": "处理中...",
@@ -221,7 +229,9 @@
     "allowPreview": "允许预览",
     "allowPreviewDescription": "是否允许在分享页面预览文件内容",
     "shareLink": "分享链接",
-    "sendLink": "发送链接"
+    "sendLink": "发送链接",
+    "directoryDownloadReplaceNotifiction": "已覆盖 {{name}}",
+    "directoryDownloadSkipNotifiction": "已跳过 {{name}}"
   },
   "uploader": {
     "fileNotMatchError": "所选择文件与原始文件不符",

--- a/public/locales/zh-CN/application.json
+++ b/public/locales/zh-CN/application.json
@@ -170,7 +170,8 @@
     "selectDirectoryDuplicationMethod": "重复对象处理方式",
     "directoryDownloadStarted": "下载已开始，请不要关闭此标签页",
     "directoryDownloadError": "下载 {{name}} 遇到错误：{{msg}}",
-    "directoryDownloadFinished": "下载完成"
+    "directoryDownloadFinished": "下载完成，无失败对象",
+    "directoryDownloadFinishedWithError": "下载完成, 失败 {{failed}} 个对象"
   },
   "modals": {
     "processing": "处理中...",

--- a/public/locales/zh-CN/application.json
+++ b/public/locales/zh-CN/application.json
@@ -170,7 +170,8 @@
     "selectDirectoryDuplicationMethod": "重复对象处理方式",
     "directoryDownloadStarted": "下载已开始，请不要关闭此标签页",
     "directoryDownloadFinished": "下载完成，无失败对象",
-    "directoryDownloadFinishedWithError": "下载完成, 失败 {{failed}} 个对象"
+    "directoryDownloadFinishedWithError": "下载完成, 失败 {{failed}} 个对象",
+    "directoryDownloadPermissionError": "无权限操作，请允许读写本地文件"
   },
   "modals": {
     "processing": "处理中...",

--- a/public/locales/zh-CN/application.json
+++ b/public/locales/zh-CN/application.json
@@ -237,7 +237,8 @@
     "directoryDownloadStarted": "开始下载 {{name}}",
     "directoryDownloadFinished": "下载完成",
     "directoryDownloadError": "遇到错误：{{msg}}",
-    "directoryDownloadErrorNotification": "下载 {{name}} 遇到错误：{{msg}}"
+    "directoryDownloadErrorNotification": "下载 {{name}} 遇到错误：{{msg}}",
+    "directoryDownloadAutoscroll": "自动滚动"
   },
   "uploader": {
     "fileNotMatchError": "所选择文件与原始文件不符",

--- a/src/component/FileManager/ContextMenu.js
+++ b/src/component/FileManager/ContextMenu.js
@@ -175,9 +175,9 @@ const mapDispatchToProps = (dispatch) => {
         batchGetSource: () => {
             dispatch(batchGetSource());
         },
-        startDirectoryDownload:(share) => {
+        startDirectoryDownload: (share) => {
             dispatch(startDirectoryDownload(share));
-        } 
+        },
     };
 };
 
@@ -202,7 +202,7 @@ class ContextMenuCompoment extends Component {
 
     openDirectoryDownload = () => {
         this.props.startDirectoryDownload(this.props.share);
-    }
+    };
 
     openDownload = () => {
         this.props.startDownload(this.props.share, this.props.selected[0]);
@@ -468,20 +468,23 @@ class ContextMenuCompoment extends Component {
                                 </div>
                             )}
 
-                            {(this.props.isMultiple ||
-                                this.props.withFolder && window.showDirectoryPicker) && (
-                                <MenuItem
-                                    dense
-                                    onClick={() => this.openDirectoryDownload()}
-                                >
-                                    <StyledListItemIcon>
+                            {(this.props.isMultiple || this.props.withFolder) &&
+                                window.showDirectoryPicker &&
+                                window.isSecureContext && (
+                                    <MenuItem
+                                        dense
+                                        onClick={() =>
+                                            this.openDirectoryDownload()
+                                        }
+                                    >
+                                        <StyledListItemIcon>
                                             <DownloadIcon />
                                         </StyledListItemIcon>
                                         <Typography variant="inherit">
                                             {t("fileManager.download")}
                                         </Typography>
-                                </MenuItem>
-                            )}
+                                    </MenuItem>
+                                )}
 
                             {(this.props.isMultiple ||
                                 this.props.withFolder) && (

--- a/src/component/FileManager/ContextMenu.js
+++ b/src/component/FileManager/ContextMenu.js
@@ -18,7 +18,12 @@ import MoveIcon from "@material-ui/icons/Input";
 import LinkIcon from "@material-ui/icons/InsertLink";
 import OpenIcon from "@material-ui/icons/OpenInNew";
 import ShareIcon from "@material-ui/icons/Share";
-import { FolderUpload, MagnetOn, FilePlus } from "mdi-material-ui";
+import {
+    FolderDownload,
+    FolderUpload,
+    MagnetOn,
+    FilePlus,
+} from "mdi-material-ui";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
@@ -478,7 +483,7 @@ class ContextMenuCompoment extends Component {
                                         }
                                     >
                                         <StyledListItemIcon>
-                                            <DownloadIcon />
+                                            <FolderDownload />
                                         </StyledListItemIcon>
                                         <Typography variant="inherit">
                                             {t("fileManager.download")}

--- a/src/component/FileManager/ContextMenu.js
+++ b/src/component/FileManager/ContextMenu.js
@@ -32,6 +32,7 @@ import {
     openPreview,
     setSelectedTarget,
     startBatchDownload,
+    startDirectoryDownload,
     startDownload,
     toggleObjectInfoSidebar,
 } from "../../redux/explorer/action";
@@ -174,6 +175,9 @@ const mapDispatchToProps = (dispatch) => {
         batchGetSource: () => {
             dispatch(batchGetSource());
         },
+        startDirectoryDownload:(share) => {
+            dispatch(startDirectoryDownload(share));
+        } 
     };
 };
 
@@ -195,6 +199,10 @@ class ContextMenuCompoment extends Component {
     openArchiveDownload = () => {
         this.props.startBatchDownload(this.props.share);
     };
+
+    openDirectoryDownload = () => {
+        this.props.startDirectoryDownload(this.props.share);
+    }
 
     openDownload = () => {
         this.props.startDownload(this.props.share, this.props.selected[0]);
@@ -458,6 +466,21 @@ class ContextMenuCompoment extends Component {
                                         <Divider className={classes.divider} />
                                     )}
                                 </div>
+                            )}
+
+                            {(this.props.isMultiple ||
+                                this.props.withFolder && window.showDirectoryPicker) && (
+                                <MenuItem
+                                    dense
+                                    onClick={() => this.openDirectoryDownload()}
+                                >
+                                    <StyledListItemIcon>
+                                            <DownloadIcon />
+                                        </StyledListItemIcon>
+                                        <Typography variant="inherit">
+                                            {t("fileManager.download")}
+                                        </Typography>
+                                </MenuItem>
                             )}
 
                             {(this.props.isMultiple ||

--- a/src/component/FileManager/Modals.js
+++ b/src/component/FileManager/Modals.js
@@ -16,6 +16,7 @@ import {
 } from "@material-ui/core";
 import Loading from "../Modals/Loading";
 import CopyDialog from "../Modals/Copy";
+import DirectoryDownloadDialog from "../Modals/DirectoryDownload";
 import CreatShare from "../Modals/CreateShare";
 import { withRouter } from "react-router-dom";
 import DecompressDialog from "../Modals/Decompress";
@@ -1004,6 +1005,12 @@ class ModalsCompoment extends Component {
                     presentPath={this.props.path}
                     selected={this.props.selected}
                     modalsLoading={this.props.modalsLoading}
+                />
+                <DirectoryDownloadDialog
+                    open={this.props.modalsStatus.directoryDownloading}
+                    onClose={this.onClose}
+                    done={this.props.modalsStatus.directoryDownloadDone}
+                    log={this.props.modalsStatus.directoryDownloadLog}
                 />
             </div>
         );

--- a/src/component/Modals/DirectoryDownload.js
+++ b/src/component/Modals/DirectoryDownload.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useState, useEffect, useRef } from "react";
 import {
     Button,
     CircularProgress,
@@ -8,6 +8,9 @@ import {
     DialogContentText,
     DialogTitle,
     makeStyles,
+    FormControl,
+    FormControlLabel,
+    Checkbox,
 } from "@material-ui/core";
 import PathSelector from "../FileManager/PathSelector";
 import { useDispatch } from "react-redux";
@@ -42,9 +45,19 @@ export default function DirectoryDownloadDialog(props) {
 
     const classes = useStyles();
 
+    const logRef = useRef();
+    const autoScroll = useRef(true);
+
+    useEffect(() => {
+        if (autoScroll.current && logRef.current) {
+            logRef.current.scrollIntoView({ behavior: "smooth", block: "end" });
+        }
+    }, [props.log]);
+
     return (
         <Dialog
             open={props.open}
+            // open
             onClose={props.onClose}
             aria-labelledby="form-dialog-title"
             fullWidth
@@ -54,22 +67,36 @@ export default function DirectoryDownloadDialog(props) {
             </DialogTitle>
 
             <DialogContent className={classes.contentFix}>
-                <DialogContentText>
-                    <TextField
-                        value={props.log}
-                        multiline
-                        fullWidth
-                        autoFocus
-                        id="standard-basic"
-                    />
-                </DialogContentText>
+                <TextField
+                    value={props.log}
+                    ref={logRef}
+                    multiline
+                    fullWidth
+                    autoFocus
+                    id="standard-basic"
+                />
             </DialogContent>
             <DialogActions>
-                <Button onClick={props.onClose}>
+                <FormControlLabel
+                    control={
+                        <Checkbox
+                            checked={autoScroll.current}
+                            onChange={() =>
+                                (autoScroll.current = !autoScroll.current)
+                            }
+                        />
+                    }
+                    label={t("modals.directoryDownloadAutoscroll")}
+                />
+                <Button onClick={props.onClose} disabled>
                     {t("cancel", { ns: "common" })}
                 </Button>
                 <div className={classes.wrapper}>
-                    <Button color="primary" disabled={!props.done}>
+                    <Button
+                        color="primary"
+                        disabled={!props.done}
+                        onClick={props.onClose}
+                    >
                         {t("ok", { ns: "common" })}
                         {!props.done && (
                             <CircularProgress

--- a/src/component/Modals/DirectoryDownload.js
+++ b/src/component/Modals/DirectoryDownload.js
@@ -12,22 +12,16 @@ import {
     FormControlLabel,
     Checkbox,
 } from "@material-ui/core";
-import PathSelector from "../FileManager/PathSelector";
 import { useDispatch } from "react-redux";
 import TextField from "@material-ui/core/TextField";
-import { setModalsLoading, toggleSnackbar } from "../../redux/explorer";
-import { submitCompressTask } from "../../redux/explorer/action";
 import { useTranslation } from "react-i18next";
 import { useInterval } from "ahooks";
+import { cancelDirectoryDownload } from "../../redux/explorer/action";
 
 const useStyles = makeStyles((theme) => ({
     contentFix: {
         padding: "10px 24px 0px 24px",
         backgroundColor: theme.palette.background.default,
-    },
-    wrapper: {
-        margin: theme.spacing(1),
-        position: "relative",
     },
     buttonProgress: {
         color: theme.palette.secondary.light,
@@ -41,8 +35,6 @@ const useStyles = makeStyles((theme) => ({
 
 export default function DirectoryDownloadDialog(props) {
     const { t } = useTranslation();
-
-    const dispatch = useDispatch();
 
     const classes = useStyles();
 
@@ -89,7 +81,9 @@ export default function DirectoryDownloadDialog(props) {
                     }
                     label={t("modals.directoryDownloadAutoscroll")}
                 />
-                <Button onClick={props.onClose} disabled>
+                <Button
+                    onClick={props.done ? props.onClose : cancelDirectoryDownload}
+                >
                     {t("cancel", { ns: "common" })}
                 </Button>
                 <div className={classes.wrapper}>

--- a/src/component/Modals/DirectoryDownload.js
+++ b/src/component/Modals/DirectoryDownload.js
@@ -1,0 +1,85 @@
+import React, { useCallback, useState } from "react";
+import {
+    Button,
+    CircularProgress,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle,
+    makeStyles,
+} from "@material-ui/core";
+import PathSelector from "../FileManager/PathSelector";
+import { useDispatch } from "react-redux";
+import TextField from "@material-ui/core/TextField";
+import { setModalsLoading, toggleSnackbar } from "../../redux/explorer";
+import { submitCompressTask } from "../../redux/explorer/action";
+import { useTranslation } from "react-i18next";
+
+const useStyles = makeStyles((theme) => ({
+    contentFix: {
+        padding: "10px 24px 0px 24px",
+        backgroundColor: theme.palette.background.default,
+    },
+    wrapper: {
+        margin: theme.spacing(1),
+        position: "relative",
+    },
+    buttonProgress: {
+        color: theme.palette.secondary.light,
+        position: "absolute",
+        top: "50%",
+        left: "50%",
+        marginTop: -12,
+        marginLeft: -12,
+    },
+}));
+
+export default function DirectoryDownloadDialog(props) {
+    const { t } = useTranslation();
+
+    const dispatch = useDispatch();
+
+    const classes = useStyles();
+
+    return (
+        <Dialog
+            open={props.open}
+            onClose={props.onClose}
+            aria-labelledby="form-dialog-title"
+            fullWidth
+        >
+            <DialogTitle id="form-dialog-title">
+                {t("modals.directoryDownloadTitle")}
+            </DialogTitle>
+
+            <DialogContent className={classes.contentFix}>
+                <DialogContentText>
+                    <TextField
+                        value={props.log}
+                        multiline
+                        fullWidth
+                        autoFocus
+                        id="standard-basic"
+                    />
+                </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={props.onClose}>
+                    {t("cancel", { ns: "common" })}
+                </Button>
+                <div className={classes.wrapper}>
+                    <Button color="primary" disabled={!props.done}>
+                        {t("ok", { ns: "common" })}
+                        {!props.done && (
+                            <CircularProgress
+                                size={24}
+                                className={classes.buttonProgress}
+                            />
+                        )}
+                    </Button>
+                </div>
+            </DialogActions>
+        </Dialog>
+    );
+}

--- a/src/component/Modals/DirectoryDownload.js
+++ b/src/component/Modals/DirectoryDownload.js
@@ -18,6 +18,7 @@ import TextField from "@material-ui/core/TextField";
 import { setModalsLoading, toggleSnackbar } from "../../redux/explorer";
 import { submitCompressTask } from "../../redux/explorer/action";
 import { useTranslation } from "react-i18next";
+import { useInterval } from "ahooks";
 
 const useStyles = makeStyles((theme) => ({
     contentFix: {
@@ -48,11 +49,11 @@ export default function DirectoryDownloadDialog(props) {
     const logRef = useRef();
     const autoScroll = useRef(true);
 
-    useEffect(() => {
-        if (autoScroll.current && logRef.current) {
+    useInterval(() => {
+        if (autoScroll.current && !props.done && logRef.current) {
             logRef.current.scrollIntoView({ behavior: "smooth", block: "end" });
         }
-    }, [props.log]);
+    }, 1000);
 
     return (
         <Dialog

--- a/src/component/Navbar/Navbar.js
+++ b/src/component/Navbar/Navbar.js
@@ -63,7 +63,7 @@ import {
     showImgPreivew,
     toggleSnackbar,
 } from "../../redux/explorer";
-import { startBatchDownload, startDownload } from "../../redux/explorer/action";
+import { startBatchDownload,startDirectoryDownload, startDownload } from "../../redux/explorer/action";
 import { withTranslation } from "react-i18next";
 
 vhCheck();
@@ -144,6 +144,9 @@ const mapDispatchToProps = (dispatch) => {
         },
         startBatchDownload: (share) => {
             dispatch(startBatchDownload(share));
+        },
+        startDirectoryDownload: (share) => {
+            dispatch(startDirectoryDownload(share));
         },
         startDownload: (share, file) => {
             dispatch(startDownload(share, file));
@@ -332,6 +335,10 @@ class NavbarCompoment extends Component {
 
     openDownload = () => {
         this.props.startDownload(this.props.shareInfo, this.props.selected[0]);
+    };
+
+    openDirectoryDownload = (e) => {
+        this.props.startDirectoryDownload(this.props.shareInfo);
     };
 
     archiveDownload = (e) => {
@@ -688,6 +695,32 @@ class NavbarCompoment extends Component {
                                                 </Tooltip>
                                             </Grow>
                                         )}
+                                    {(this.props.isMultiple ||
+                                        (this.props.withFolder &&
+                                            window.showDirectoryPicker)) && (
+                                        <Grow
+                                            in={
+                                                this.props.isMultiple ||
+                                                (this.props.withFolder &&
+                                                    window.showDirectoryPicker)
+                                            }
+                                        >
+                                            <Tooltip
+                                                title={t(
+                                                    "fileManager.download"
+                                                )}
+                                            >
+                                                <IconButton
+                                                    color="inherit"
+                                                    onClick={() =>
+                                                        this.openDirectoryDownload()
+                                                    }
+                                                >
+                                                    <DownloadIcon />
+                                                </IconButton>
+                                            </Tooltip>
+                                        </Grow>
+                                    )}
                                     {(this.props.isMultiple ||
                                         this.props.withFolder) && (
                                         <Grow

--- a/src/component/Navbar/Navbar.js
+++ b/src/component/Navbar/Navbar.js
@@ -19,7 +19,12 @@ import SezrchBar from "./SearchBar";
 import StorageBar from "./StorageBar";
 import UserAvatar from "./UserAvatar";
 import UserInfo from "./UserInfo";
-import { AccountArrowRight, AccountPlus, LogoutVariant } from "mdi-material-ui";
+import {
+    FolderDownload,
+    AccountArrowRight,
+    AccountPlus,
+    LogoutVariant,
+} from "mdi-material-ui";
 import { withRouter } from "react-router-dom";
 import {
     AppBar,
@@ -63,7 +68,11 @@ import {
     showImgPreivew,
     toggleSnackbar,
 } from "../../redux/explorer";
-import { startBatchDownload,startDirectoryDownload, startDownload } from "../../redux/explorer/action";
+import {
+    startBatchDownload,
+    startDirectoryDownload,
+    startDownload,
+} from "../../redux/explorer/action";
 import { withTranslation } from "react-i18next";
 
 vhCheck();
@@ -697,30 +706,33 @@ class NavbarCompoment extends Component {
                                         )}
                                     {(this.props.isMultiple ||
                                         this.props.withFolder) &&
-                                            window.showDirectoryPicker && window.isSecureContext && (
-                                        <Grow
-                                            in={
-                                                (this.props.isMultiple ||
-                                                    this.props.withFolder) &&
-                                                        window.showDirectoryPicker && window.isSecureContext
-                                            }
-                                        >
-                                            <Tooltip
-                                                title={t(
-                                                    "fileManager.download"
-                                                )}
+                                        window.showDirectoryPicker &&
+                                        window.isSecureContext && (
+                                            <Grow
+                                                in={
+                                                    (this.props.isMultiple ||
+                                                        this.props
+                                                            .withFolder) &&
+                                                    window.showDirectoryPicker &&
+                                                    window.isSecureContext
+                                                }
                                             >
-                                                <IconButton
-                                                    color="inherit"
-                                                    onClick={() =>
-                                                        this.openDirectoryDownload()
-                                                    }
+                                                <Tooltip
+                                                    title={t(
+                                                        "fileManager.download"
+                                                    )}
                                                 >
-                                                    <DownloadIcon />
-                                                </IconButton>
-                                            </Tooltip>
-                                        </Grow>
-                                    )}
+                                                    <IconButton
+                                                        color="inherit"
+                                                        onClick={() =>
+                                                            this.openDirectoryDownload()
+                                                        }
+                                                    >
+                                                        <FolderDownload />
+                                                    </IconButton>
+                                                </Tooltip>
+                                            </Grow>
+                                        )}
                                     {(this.props.isMultiple ||
                                         this.props.withFolder) && (
                                         <Grow

--- a/src/component/Navbar/Navbar.js
+++ b/src/component/Navbar/Navbar.js
@@ -696,13 +696,13 @@ class NavbarCompoment extends Component {
                                             </Grow>
                                         )}
                                     {(this.props.isMultiple ||
-                                        (this.props.withFolder &&
-                                            window.showDirectoryPicker)) && (
+                                        this.props.withFolder) &&
+                                            window.showDirectoryPicker && window.isSecureContext && (
                                         <Grow
                                             in={
-                                                this.props.isMultiple ||
-                                                (this.props.withFolder &&
-                                                    window.showDirectoryPicker)
+                                                (this.props.isMultiple ||
+                                                    this.props.withFolder) &&
+                                                        window.showDirectoryPicker && window.isSecureContext
                                             }
                                         >
                                             <Tooltip

--- a/src/redux/explorer/action.ts
+++ b/src/redux/explorer/action.ts
@@ -483,6 +483,7 @@ export const startDirectoryDownload = (
 
         dispatch(closeAllModals());
 
+        let failed = 0;
         try {
             const handle = await window.showDirectoryPicker({
                 startIn: "downloads",
@@ -575,32 +576,35 @@ export const startDirectoryDownload = (
                         `${path}/`
                     );
                     try {
-                        console.log(name, duplicates);
                         if (duplicates.includes(name)) {
-                            if (option === "skip") {
-                                toggleSnackbar(
-                                    "top",
-                                    "right",
-                                    i18next.t(
-                                        "modals.directoryDownloadSkipNotifiction",
-                                        {
-                                            name,
-                                        }
-                                    ),
-                                    "warning"
+                            if (option.key === "skip") {
+                                dispatch(
+                                    toggleSnackbar(
+                                        "top",
+                                        "right",
+                                        i18next.t(
+                                            "modals.directoryDownloadSkipNotifiction",
+                                            {
+                                                name,
+                                            }
+                                        ),
+                                        "warning"
+                                    )
                                 );
                                 continue;
                             } else {
-                                toggleSnackbar(
-                                    "top",
-                                    "right",
-                                    i18next.t(
-                                        "modals.directoryDownloadReplaceNotifiction",
-                                        {
-                                            name,
-                                        }
-                                    ),
-                                    "warning"
+                                dispatch(
+                                    toggleSnackbar(
+                                        "top",
+                                        "right",
+                                        i18next.t(
+                                            "modals.directoryDownloadReplaceNotifiction",
+                                            {
+                                                name,
+                                            }
+                                        ),
+                                        "warning"
+                                    )
                                 );
                             }
                         }
@@ -612,20 +616,22 @@ export const startDirectoryDownload = (
                             name
                         );
                     } catch (e) {
-                        toggleSnackbar(
-                            "top",
-                            "right",
-                            i18next.t("modals.directoryDownloadError", {
-                                name,
-                                message: e && e.message,
-                            }),
-                            "warning"
+                        failed++;
+                        dispatch(
+                            toggleSnackbar(
+                                "top",
+                                "right",
+                                i18next.t("modals.directoryDownloadError", {
+                                    name,
+                                    message: e && e.message,
+                                }),
+                                "warning"
+                            )
                         );
                     }
                 }
             }
         } catch (e) {
-            console.log(e);
             toggleSnackbar(
                 "top",
                 "right",
@@ -641,8 +647,15 @@ export const startDirectoryDownload = (
             toggleSnackbar(
                 "top",
                 "center",
-                i18next.t("fileManager.directoryDownloadFinished"),
-                "info"
+                failed === 0
+                    ? i18next.t("fileManager.directoryDownloadFinished")
+                    : i18next.t(
+                          "fileManager.directoryDownloadFinishedWithError",
+                          {
+                              failed,
+                          }
+                      ),
+                "success"
             )
         );
     };

--- a/src/redux/explorer/action.ts
+++ b/src/redux/explorer/action.ts
@@ -453,7 +453,7 @@ export const startDirectoryDownload = (
     share: any
 ): ThunkAction<any, any, any, any> => {
     return async (dispatch, getState): Promise<void> => {
-        if (!window.showDirectoryPicker) {
+        if (!window.showDirectoryPicker || !window.isSecureContext) {
             return;
         }
         dispatch(changeContextMenu("file", false));

--- a/src/redux/explorer/index.ts
+++ b/src/redux/explorer/index.ts
@@ -281,3 +281,12 @@ export const setSiteConfig = (config) => {
         config: config,
     };
 };
+
+export const openDirectoryDownloadDialog = (downloading, log, done) => {
+    return {
+        type: "OPEN_DIRECTORY_DOWNLOAD_DIALOG",
+        downloading,
+        log,
+        done,
+    };
+};

--- a/src/redux/viewUpdate/reducer.ts
+++ b/src/redux/viewUpdate/reducer.ts
@@ -35,6 +35,9 @@ export interface ViewUpdateState {
         decompress: boolean;
         loading: boolean;
         loadingText: string;
+        directoryDownloading: boolean;
+        directoryDownloadLog: string;
+        directoryDownloadDone: boolean;
         option?: {
             options: {
                 open: boolean;
@@ -96,6 +99,9 @@ export const initState: ViewUpdateState = {
         decompress: false,
         loading: false,
         loadingText: "",
+        directoryDownloading: false,
+        directoryDownloadLog: "",
+        directoryDownloadDone: false,
     },
     snackbar: {
         toggle: false,
@@ -246,6 +252,15 @@ const viewUpdate = (state: ViewUpdateState = initState, action: AnyAction) => {
                 }),
                 contextOpen: false,
             });
+        case "OPEN_DIRECTORY_DOWNLOAD_DIALOG":
+            return Object.assign({}, state, {
+                modals: Object.assign({}, state.modals, {
+                    directoryDownloading: action.downloading,
+                    directoryDownloadLog: action.log,
+                    directoryDownloadDone: action.done,
+                }),
+                contextOpen: false,
+            });
         case "CLOSE_CONTEXT_MENU":
             return Object.assign({}, state, {
                 contextOpen: false,
@@ -269,6 +284,9 @@ const viewUpdate = (state: ViewUpdateState = initState, action: AnyAction) => {
                     compress: false,
                     decompress: false,
                     option: undefined,
+                    directoryDownloading: false,
+                    directoryDownloadLog: "",
+                    directoryDownloadDone: false,
                 }),
             });
         case "TOGGLE_SNACKBAR":

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -4,7 +4,7 @@ module.exports = function (app) {
     app.use(
         "/api",
         proxy({
-            target: "http://localhost:5212",
+            target: "https://pan.huang1111.cn",
             changeOrigin: true,
         })
     );
@@ -12,7 +12,7 @@ module.exports = function (app) {
     app.use(
         "/custom",
         proxy({
-            target: "http://localhost:5212",
+            target: "https://pan.huang1111.cn",
             changeOrigin: true,
         })
     );

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -4,7 +4,7 @@ module.exports = function (app) {
     app.use(
         "/api",
         proxy({
-            target: "https://pan.huang1111.cn",
+            target: "http://localhost:5212",
             changeOrigin: true,
         })
     );
@@ -12,7 +12,7 @@ module.exports = function (app) {
     app.use(
         "/custom",
         proxy({
-            target: "https://pan.huang1111.cn",
+            target: "http://localhost:5212",
             changeOrigin: true,
         })
     );

--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -1,0 +1,54 @@
+export const getFileSystemDirectoryPaths = async (
+    handle: FileSystemDirectoryHandle,
+    parent = ""
+): Promise<string[]> => {
+    const paths: Array<string> = [];
+
+    for await (const [path, fileSystemHandle] of handle.entries()) {
+        if (fileSystemHandle instanceof window.FileSystemFileHandle) {
+            paths.push(`${parent}${path}`);
+        } else {
+            paths.push(
+                ...(await getFileSystemDirectoryPaths(
+                    fileSystemHandle,
+                    `${parent}${path}/`
+                ))
+            );
+        }
+    }
+
+    return paths;
+};
+
+// path: a/b/c
+export const createFileSystemDirectory = async (
+    handle: FileSystemDirectoryHandle,
+    paths: string[]
+) => {
+    let cur = handle;
+    while (paths.length > 0) {
+        const path = paths.shift();
+        if (!path) {
+            break;
+        }
+        cur = await cur.getDirectoryHandle(path, { create: true });
+    }
+    return cur;
+};
+
+// path: a/b/c.jpg
+export const saveFileToFileSystemDirectory = async (
+    handle: FileSystemDirectoryHandle,
+    stream: Blob,
+    path: string
+) => {
+    const paths = path.split("/");
+    const fileName = paths.pop();
+    if (!fileName) return;
+
+    const dir = await createFileSystemDirectory(handle, paths);
+    const file = await dir.getFileHandle(fileName, { create: true });
+    const writable = await file.createWritable();
+    await writable.write(stream);
+    await writable.close();
+};

--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -1,3 +1,5 @@
+// get the paths of files (no directories) in the directory
+// parent: "" or "/"
 export const getFileSystemDirectoryPaths = async (
     handle: FileSystemDirectoryHandle,
     parent = ""
@@ -20,7 +22,9 @@ export const getFileSystemDirectoryPaths = async (
     return paths;
 };
 
-// path: a/b/c
+// create the dst directory if it doesn't exist
+// return the dst directory handle
+// paths: "/dir1/dir2" => ["dir1","dir2"]
 export const createFileSystemDirectory = async (
     handle: FileSystemDirectoryHandle,
     paths: string[]
@@ -36,19 +40,42 @@ export const createFileSystemDirectory = async (
     return cur;
 };
 
+// save file into the dst directory
+// create the dst file if it doesn't exist by default
 // path: a/b/c.jpg
 export const saveFileToFileSystemDirectory = async (
     handle: FileSystemDirectoryHandle,
-    stream: Blob,
-    path: string
+    stream: FileSystemWriteChunkType,
+    path: string,
+    create = true
 ) => {
     const paths = path.split("/");
     const fileName = paths.pop();
     if (!fileName) return;
 
     const dir = await createFileSystemDirectory(handle, paths);
-    const file = await dir.getFileHandle(fileName, { create: true });
+    const file = await dir.getFileHandle(fileName, { create });
     const writable = await file.createWritable();
     await writable.write(stream);
     await writable.close();
 };
+
+// verify or request the permission of the readwrite permission
+export async function verifyFileSystemRWPermission(
+    fileHandle: FileSystemDirectoryHandle
+) {
+    const opts = { mode: "readwrite" as FileSystemPermissionMode };
+
+    // Check if we already have permission, if so, return true.
+    if ((await fileHandle.queryPermission(opts)) === "granted") {
+        return true;
+    }
+
+    // Request permission to the file, if the user grants permission, return true.
+    if ((await fileHandle.requestPermission(opts)) === "granted") {
+        return true;
+    }
+
+    // The user did not grant permission, return false.
+    return false;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1875,6 +1875,11 @@
   resolved "https://registry.yarnpkg.com/@types/streamsaver/-/streamsaver-2.0.1.tgz#fa5e5b891d1b282be3078c232a30ee004b8e0be0"
   integrity sha512-I49NtT8w6syBI3Zg3ixCyygTHoTVMY0z2TMRcTgccdIsVd2MwlKk7ITLHLsJtgchUHcOd7QEARG9h0ifcA6l2Q==
 
+"@types/wicg-file-system-access@^2020.9.5":
+  version "2020.9.5"
+  resolved "https://registry.yarnpkg.com/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.5.tgz#4a0c8f3d1ed101525f329e86c978f7735404474f"
+  integrity sha512-UYK244awtmcUYQfs7FR8710MJcefL2WvkyHMjA8yJzxd1mo0Gfn88sRZ1Bls7hiUhA2w7ne1gpJ9T5g3G0wOyA==
+
 "@types/yargs-parser@*":
   version "20.2.1"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,6 +1775,11 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
+"@types/js-cookie@^2.x.x":
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.7.tgz#226a9e31680835a6188e887f3988e60c04d3f6a3"
+  integrity sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==
+
 "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.5":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
@@ -2176,6 +2181,25 @@ adjust-sourcemap-loader@2.0.0:
     loader-utils "1.2.3"
     object-path "0.11.4"
     regex-parser "2.2.10"
+
+ahooks-v3-count@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ahooks-v3-count/-/ahooks-v3-count-1.0.0.tgz#ddeb392e009ad6e748905b3cbf63a9fd8262ca80"
+  integrity sha512-V7uUvAwnimu6eh/PED4mCDjE7tokeZQLKlxg9lCTMPhN+NjsSbtdacByVlR1oluXQzD3MOw55wylDmQo4+S9ZQ==
+
+ahooks@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/ahooks/-/ahooks-3.5.2.tgz#283e4b2796d3e00f0a280f0f09e2517feaa434e3"
+  integrity sha512-0OrV3/9s339comBg/F+d9Q7lhZERZK3K5f1J8ebK3z076Kc4KkeGc1MLalFRG+95nVA0wUCZ71oJMs66fIU2Uw==
+  dependencies:
+    "@types/js-cookie" "^2.x.x"
+    ahooks-v3-count "^1.0.0"
+    dayjs "^1.9.1"
+    intersection-observer "^0.12.0"
+    js-cookie "^2.x.x"
+    lodash "^4.17.21"
+    resize-observer-polyfill "^1.5.1"
+    screenfull "^5.0.0"
 
 ajv-errors@^1.0.0:
   version "1.0.1"
@@ -3984,6 +4008,11 @@ dayjs@^1.10.4:
   version "1.10.8"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.8.tgz#267df4bc6276fcb33c04a6735287e3f429abec41"
   integrity sha512-wbNwDfBHHur9UOzNUjeKUOJ0fCb0a52Wx0xInmQ7Y8FstyajiV1NmK1e00cxsr9YrE9r7yAChE0VvpuY5Rnlow==
+
+dayjs@^1.9.1:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.3.tgz#4754eb694a624057b9ad2224b67b15d552589258"
+  integrity sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
@@ -6026,6 +6055,11 @@ internmap@^1.0.0:
   resolved "https://registry.yarnpkg.com/internmap/-/internmap-1.0.1.tgz#0017cc8a3b99605f0302f2b198d272e015e5df95"
   integrity sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==
 
+intersection-observer@^0.12.0:
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.12.2.tgz#4a45349cc0cd91916682b1f44c28d7ec737dc375"
+  integrity sha512-7m1vEcPCxXYI8HqnL8CKI6siDyD+eIWSwgB3DZA+ZTogxk9I4CDnj4wilt9x/+/QbHI4YG5YZNmC6458/e9Ktg==
+
 invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
@@ -6850,6 +6884,11 @@ jest@24.9.0:
   dependencies:
     import-local "^2.0.0"
     jest-cli "^24.9.0"
+
+js-cookie@^2.x.x:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -10378,6 +10417,11 @@ schema-utils@^2.0.0, schema-utils@^2.0.1, schema-utils@^2.2.0:
     "@types/json-schema" "^7.0.5"
     ajv "^6.12.4"
     ajv-keywords "^3.5.2"
+
+screenfull@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-5.2.0.tgz#6533d524d30621fc1283b9692146f3f13a93d1ba"
+  integrity sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==
 
 screenfull@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
This PR introduces an experimental API [File System Access API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API) so that we can directly and easily access the user's filesystem. It will keep the original structure.

Due to its poor [Browser compatibility](https://developer.mozilla.org/en-US/docs/Web/API/window/showDirectoryPicker#browser_compatibility), this feature is enabled only when using the supported browser, and the entrance won't be displayed.

The following are the tasks to be done
- [x] Rechoose a proper icon for `Archiving Batch Download` or `Directory Download` (they are confusing)
- [x] English translation
- [x] Improve the UI of transmission queue
- [x] Check in secure contexts
- [x] Cancel download task

Update: everything is ready!