### PR TITLE
fix:修复timezone无法识别时的Bug

### DIFF
--- a/src/utils/datetime.js
+++ b/src/utils/datetime.js
@@ -14,7 +14,7 @@ try {
     console.log(e);
 }
 
-if (!userTimezone) {
+if (!userTimezone || userTimezone=="Etc/Unknown") {
     userTimezone = "Asia/Shanghai";
 }
 


### PR DESCRIPTION
在Deepin等linux发行版中,可以设置wuhan等时区信息
在chrome等浏览器中,无法正确识别时区信息,会导致
出现bug(文件属性信息无法正常显示显示),添加
Etc/Unknown兼容处理