### PR TITLE
chore: add eslint rules for nodejs `required`

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -38,3 +38,6 @@ overrides:
   - files: ['*.js', '*.jsx']
     rules:
       '@typescript-eslint/camelcase': 0
+  - files: ['config/*.js', 'scripts/*.js']
+    rules:
+      '@typescript-eslint/no-var-requires': 0


### PR DESCRIPTION
shut off `@typescript-eslint/no-var-requires` for js files in folder `config` and folder `scripts`

<img width="747" alt="1678257955497" src="https://user-images.githubusercontent.com/32612643/223646888-9606bb49-055d-405b-a303-0f54fb512d74.png">
