### PR TITLE
fix: remove html lang to fix translator popup

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-cn">
+<html>
     <head>
         <meta charset="utf-8" />
         <link rel="shortcut icon" href="{pwa_small_icon}" sizes="64x64"/>


### PR DESCRIPTION
Fixes the annoying translator on each page visit:
![image](https://github.com/cloudreve/frontend/assets/6224096/337f5469-6620-4f0d-ac28-ed3bd05551b7)
