### PR TITLE
添加默认全量批量下载按钮、无选择则等同选择全部

### DIFF
--- a/src/component/FileManager/Navigator/SubActions.js
+++ b/src/component/FileManager/Navigator/SubActions.js
@@ -4,11 +4,12 @@ import ViewListIcon from "@material-ui/icons/ViewList";
 import ViewSmallIcon from "@material-ui/icons/ViewComfy";
 import ViewModuleIcon from "@material-ui/icons/ViewModule";
 import TextTotateVerticalIcon from "@material-ui/icons/TextRotateVertical";
+import DownloadIcon from "@material-ui/icons/CloudDownload";
 import Avatar from "@material-ui/core/Avatar";
 import { useDispatch, useSelector } from "react-redux";
 import Auth from "../../../middleware/Auth";
 import { changeViewMethod, setShareUserPopover } from "../../../redux/explorer";
-import { changeSortMethod } from "../../../redux/explorer/action";
+import { changeSortMethod, startBatchDownload } from "../../../redux/explorer/action";
 import { FormatPageBreak } from "mdi-material-ui";
 import pathHelper from "../../../utils/page";
 import { changePageSize } from "../../../redux/viewUpdate/action";
@@ -54,6 +55,10 @@ export default function SubActions({ isSmall, inherit }) {
     const SetShareUserPopover = useCallback(
         (e) => dispatch(setShareUserPopover(e)),
         [dispatch]
+    );
+    const StartBatchDownloadAll = useCallback(
+        () => dispatch(startBatchDownload(share)),
+        [dispatch, share]
     );
     const ChangePageSize = useCallback((e) => dispatch(changePageSize(e)), [
         dispatch,
@@ -102,6 +107,15 @@ export default function SubActions({ isSmall, inherit }) {
     const classes = useStyles();
     return (
         <>
+            <IconButton
+                title={t("batchDownload")}
+                className={classes.sideButton}
+                onClick={StartBatchDownloadAll}
+                color={inherit ? "inherit" : "default"}
+            >
+                <DownloadIcon fontSize={isSmall ? "small" : "default"} />
+            </IconButton>
+
             {viewMethod === "icon" && (
                 <IconButton
                     title={t("listView")}

--- a/src/redux/explorer/action.ts
+++ b/src/redux/explorer/action.ts
@@ -223,14 +223,15 @@ export const serverSideBatchDownload = (
             openLoadingDialog(i18next.t("fileManager.preparingBathDownload"))
         );
         const {
-            explorer: { selected },
+            explorer: { selected, fileList, dirList },
             router: {
                 location: { pathname },
             },
         } = getState();
-        const dirs: any[] = [],
-            items: any[] = [];
-        selected.map((value) => {
+        const dirs: string[] = [],
+            items: string[] = [];
+        const fileSources: CloudreveFile[] = selected.length ? selected : [...dirList, ...fileList];
+        fileSources.map((value) => {
             if (value.type === "dir") {
                 dirs.push(value.id);
             } else {
@@ -246,7 +247,7 @@ export const serverSideBatchDownload = (
         };
         if (pathHelper.isSharePage(pathname)) {
             reqURL = "/share/archive/" + share.key;
-            postBody["path"] = selected[0].path;
+            postBody["path"] = fileSources[0].path;
         }
 
         API.post(reqURL, postBody)
@@ -322,7 +323,7 @@ export const startBatchDownload = (
     return async (dispatch, getState): Promise<void> => {
         dispatch(changeContextMenu("file", false));
         const {
-            explorer: { selected },
+            explorer: { selected, fileList, dirList },
         } = getState();
 
         const user = Auth.GetUser();
@@ -368,7 +369,8 @@ export const startBatchDownload = (
 
         let queue: CloudreveFile[] = [];
         try {
-            queue = await walk(selected, share);
+            const walkSources = selected.length ? selected : [...dirList, ...fileList];
+            queue = await walk(walkSources, share);
         } catch (e) {
             dispatch(
                 toggleSnackbar(


### PR DESCRIPTION
这样的话可以在分享页面直接下载全部而无需额外操作

![image](https://github.com/cloudreve/frontend/assets/25359546/49b673ed-0e36-4028-9aba-01f8d06e3e4f)

https://github.com/cloudreve/Cloudreve/issues/1772