### PR TITLE
为弹窗类型的路径选择器`PathSelector`添加排序功能

### DIFF
--- a/src/component/FileManager/Navigator/SubActions.js
+++ b/src/component/FileManager/Navigator/SubActions.js
@@ -3,7 +3,6 @@ import { IconButton, makeStyles, Menu, MenuItem } from "@material-ui/core";
 import ViewListIcon from "@material-ui/icons/ViewList";
 import ViewSmallIcon from "@material-ui/icons/ViewComfy";
 import ViewModuleIcon from "@material-ui/icons/ViewModule";
-import TextTotateVerticalIcon from "@material-ui/icons/TextRotateVertical";
 import DownloadIcon from "@material-ui/icons/CloudDownload";
 import Avatar from "@material-ui/core/Avatar";
 import { useDispatch, useSelector } from "react-redux";
@@ -14,6 +13,7 @@ import { FormatPageBreak } from "mdi-material-ui";
 import pathHelper from "../../../utils/page";
 import { changePageSize } from "../../../redux/viewUpdate/action";
 import { useTranslation } from "react-i18next";
+import Sort from "../Sort";
 
 const useStyles = makeStyles((theme) => ({
     sideButton: {
@@ -21,17 +21,6 @@ const useStyles = makeStyles((theme) => ({
         marginRight: "5px",
     },
 }));
-
-const sortOptions = [
-    "A-Z",
-    "Z-A",
-    "oldestUploaded",
-    "newestUploaded",
-    "oldestModified",
-    "newestModified",
-    "smallest",
-    "largest",
-];
 
 const paginationOption = ["50", "100", "200", "500", "1000"];
 
@@ -63,29 +52,14 @@ export default function SubActions({ isSmall, inherit }) {
     const ChangePageSize = useCallback((e) => dispatch(changePageSize(e)), [
         dispatch,
     ]);
-    const [anchorSort, setAnchorSort] = useState(null);
     const [anchorPagination, setAnchorPagination] = useState(null);
-    const [selectedIndex, setSelectedIndex] = useState(0);
-    const showSortOptions = (e) => {
-        setAnchorSort(e.currentTarget);
-    };
     const showPaginationOptions = (e) => {
         setAnchorPagination(e.currentTarget);
     };
-    const handleMenuItemClick = (e, index) => {
-        setSelectedIndex(index);
-        const optionsTable = {
-            0: "namePos",
-            1: "nameRev",
-            2: "timePos",
-            3: "timeRev",
-            4: "modifyTimePos",
-            5: "modifyTimeRev",
-            6: "sizePos",
-            7: "sizeRes",
-        };
-        ChangeSortMethod(optionsTable[index]);
-        setAnchorSort(null);
+
+    /** change sort */
+    const onChangeSort = (value) => {
+        ChangeSortMethod(value);
     };
     const handlePaginationChange = (s) => {
         ChangePageSize(s);
@@ -181,32 +155,12 @@ export default function SubActions({ isSmall, inherit }) {
                 </MenuItem>
             </Menu>
 
-            <IconButton
-                title={t("sortMethod")}
+            <Sort
+                isSmall={isSmall}
+                inherit={inherit}
                 className={classes.sideButton}
-                onClick={showSortOptions}
-                color={inherit ? "inherit" : "default"}
-            >
-                <TextTotateVerticalIcon
-                    fontSize={isSmall ? "small" : "default"}
-                />
-            </IconButton>
-            <Menu
-                id="sort-menu"
-                anchorEl={anchorSort}
-                open={Boolean(anchorSort)}
-                onClose={() => setAnchorSort(null)}
-            >
-                {sortOptions.map((option, index) => (
-                    <MenuItem
-                        key={option}
-                        selected={index === selectedIndex}
-                        onClick={(event) => handleMenuItemClick(event, index)}
-                    >
-                        {t("sortMethods." + option)}
-                    </MenuItem>
-                ))}
-            </Menu>
+                onChange={onChangeSort}
+            />
             {share && (
                 <IconButton
                     title={t("shareCreateBy", { nick: share.creator.nick })}

--- a/src/component/FileManager/PathSelector.js
+++ b/src/component/FileManager/PathSelector.js
@@ -15,9 +15,11 @@ import {
     MenuList,
     withStyles,
 } from "@material-ui/core";
+import Sort from './Sort';
 import API from "../../middleware/Api";
 import { toggleSnackbar } from "../../redux/explorer";
 import { withTranslation } from "react-i18next";
+import { sortMethodFuncs } from "../../redux/explorer/action";
 
 const mapStateToProps = (state) => {
     return {
@@ -53,14 +55,27 @@ const styles = (theme) => ({
         maxHeight: "330px",
         overflowY: " auto",
     },
+    sortWrapper: {
+        textAlign: "right",
+        paddingRight: "30px",
+    },
+    sortButton: {
+        padding: "0",
+    },
 });
-
 class PathSelectorCompoment extends Component {
     state = {
         presentPath: "/",
+        sortBy: '',
         dirList: [],
         selectedTarget: null,
     };
+    /**
+     * the source dir list from api `/directory`
+     *
+     * `state.dirList` is a sorted copy of it
+     */
+    sourceDirList = []
 
     componentDidMount = () => {
         const toBeLoad = this.props.presentPath;
@@ -93,31 +108,11 @@ class PathSelectorCompoment extends Component {
                 dirList.forEach((value) => {
                     value.displayName = value.name;
                 });
-                if (toBeLoad === "/") {
-                    dirList.unshift({ name: "/", path: "", displayName: "/" });
-                } else {
-                    let path = toBeLoad;
-                    let name = toBeLoad;
-                    const displayNames = ["fileManager.currentFolder", "fileManager.backToParentFolder"];
-                    for (let i = 0; i < 2; i++) {
-                        const paths = path.split("/");
-                        name = paths.pop();
-                        name = name === "" ? "/" : name;
-                        path = paths.join("/");
-                        dirList.unshift({
-                            name: name,
-                            path: path,
-                            displayName: this.props.t(
-                                displayNames[i]
-                            ),
-                        });
-                    }
-                }
+                this.sourceDirList = dirList
                 this.setState({
                     presentPath: toBeLoad,
-                    dirList: dirList,
                     selectedTarget: null,
-                });
+                }, this.updateDirList);
             })
             .catch((error) => {
                 this.props.toggleSnackbar(
@@ -134,6 +129,51 @@ class PathSelectorCompoment extends Component {
         this.props.onSelect(this.state.dirList[index]);
     };
 
+
+    /**
+     * change sort type
+     * @param {Event} event
+     */
+    onChangeSort = (sortBy) => {
+        this.setState({ sortBy }, this.updateDirList)
+    };
+    
+    /**
+     * sort dir list, and handle parent dirs
+     */
+    updateDirList = () => {
+        const { state, sourceDirList } = this
+        const { sortBy, presentPath } = state
+
+        // copy
+        const dirList = [...sourceDirList]
+        // sort
+        const sortMethod = sortMethodFuncs[sortBy]
+        if (sortMethod) dirList.sort(sortMethod)
+
+        // add root/parent dirs to top
+        if (presentPath === "/") {
+            dirList.unshift({ name: "/", path: "", displayName: "/" });
+        } else {
+            let path = presentPath;
+            let name = presentPath;
+            const displayNames = ["fileManager.currentFolder", "fileManager.backToParentFolder"];
+            for (let i = 0; i < 2; i++) {
+                const paths = path.split("/");
+                name = paths.pop();
+                name = name === "" ? "/" : name;
+                path = paths.join("/");
+                dirList.unshift({
+                    name: name,
+                    path: path,
+                    displayName: this.props.t(
+                        displayNames[i]
+                    ),
+                });
+            }
+        }
+        this.setState({ dirList })
+    }
     render() {
         const { classes, t } = this.props;
 
@@ -157,6 +197,9 @@ class PathSelectorCompoment extends Component {
 
         return (
             <div className={classes.container}>
+                <div className={classes.sortWrapper}>
+                    <Sort value={this.state.sortBy} isSmall className={classes.sortButton} onChange={this.onChangeSort} />
+                </div>
                 <MenuList className={classes.selector}>
                     {this.state.dirList.map((value, index) => (
                         <MenuItem

--- a/src/component/FileManager/Sort.js
+++ b/src/component/FileManager/Sort.js
@@ -1,0 +1,74 @@
+import React, { useState } from "react";
+import { IconButton, Menu, MenuItem } from "@material-ui/core";
+import TextTotateVerticalIcon from "@material-ui/icons/TextRotateVertical";
+import { useTranslation } from "react-i18next";
+
+const SORT_TYPE = {
+    namePos: "namePos",
+    nameRev: "nameRev",
+    timePos: "timePos",
+    timeRev: "timeRev",
+    modifyTimePos: "modifyTimePos",
+    modifyTimeRev: "modifyTimeRev",
+    sizePos: "sizePos",
+    sizeRes: "sizeRes",
+}
+
+const SORT_OPTIONS = [
+    { value: SORT_TYPE.namePos, label: "A-Z" },
+    { value: SORT_TYPE.nameRev, label: "Z-A" },
+    { value: SORT_TYPE.timePos, label: "oldestUploaded" },
+    { value: SORT_TYPE.timeRev, label: "newestUploaded" },
+    { value: SORT_TYPE.modifyTimePos, label: "oldestModified" },
+    { value: SORT_TYPE.modifyTimeRev, label: "newestModified" },
+    { value: SORT_TYPE.sizePos, label: "smallest" },
+    { value: SORT_TYPE.sizeRes, label: "largest" },
+]
+
+export default function Sort({ value, onChange, isSmall, inherit, className }) {
+    const { t } = useTranslation("application", { keyPrefix: "fileManager.sortMethods" });
+
+    const [anchorSort, setAnchorSort] = useState(false);
+    function showSortOptions(e) {
+        setAnchorSort(e.currentTarget);
+    }
+    
+    const [sortBy, setSortBy] = useState(value in SORT_TYPE ? value : '')
+    function onChangeSort(value) {
+        setSortBy(value)
+        onChange(value)
+        setAnchorSort(false);
+    }
+    return (
+        <>
+            <IconButton
+                title={t("sortMethod")}
+                className={className}
+                onClick={showSortOptions}
+                color={inherit ? "inherit" : "default"}
+            >
+                <TextTotateVerticalIcon
+                    fontSize={isSmall ? "small" : "default"}
+                />
+            </IconButton>
+            <Menu
+                id="sort-menu"
+                anchorEl={anchorSort}
+                open={Boolean(anchorSort)}
+                onClose={() => setAnchorSort(null)}
+            >
+                {
+                    SORT_OPTIONS.map((option, index) => (
+                        <MenuItem
+                            key={index}
+                            selected={option.value === sortBy}
+                            onClick={() => onChangeSort(option.value)}
+                        >
+                            {t(option.label)}
+                        </MenuItem>
+                    ))
+                }
+            </Menu>
+        </>
+    )
+}


### PR DESCRIPTION
- 从主页提取排序组件，封装为`Sort`组件
- 使用新组件为`PathSelector`组件添加排序功能（fix: [#1803](https://github.com/cloudreve/Cloudreve/issues/1803)）
- 使用新组件替换主页排序代码

<img width="255" alt="image" src="https://github.com/cloudreve/frontend/assets/32612643/9c650689-dd92-4590-864c-161b89d65f9e">
<img width="305" alt="image" src="https://github.com/cloudreve/frontend/assets/32612643/5e8ddeb0-077e-4bc0-b59c-3f63dcf5d0f6">
