### PR TITLE
fix: profile页可在未登录时查看

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -167,12 +167,12 @@ export default function App() {
                                 <UserSetting />
                             </Route>
 
-                            <AuthRoute
+                            <Route
                                 path={`${path}profile/:id`}
                                 isLogin={isLogin}
                             >
                                 <Profile />
-                            </AuthRoute>
+                            </Route>
 
                             <AuthRoute path={`${path}webdav`} isLogin={isLogin}>
                                 <WebDAV />


### PR DESCRIPTION
根据Cloudreve项目代码,profile页是支持在未登录时查看的,而且还可设置是否展示主页,所以这里就去掉需要登录的限制