### PR TITLE
fix(EntityRow&FileRow): improve file and entity link opening logic (cloudreve/cloudreve#2302)

### DIFF
--- a/src/component/Admin/Entity/EntityRow.tsx
+++ b/src/component/Admin/Entity/EntityRow.tsx
@@ -50,8 +50,15 @@ const EntityRow = ({
     
     dispatch(getEntityUrl(entity?.id ?? 0))
       .then((url) => {
-        // 直接下载文件
-        window.location.assign(url);
+        // 直接下载文件：使用a标签的download属性强制下载
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `entity-${entity?.id}`;
+        link.style.display = 'none';
+        
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
       })
       .finally(() => {
         setOpenLoading(false);

--- a/src/component/Admin/Entity/EntityRow.tsx
+++ b/src/component/Admin/Entity/EntityRow.tsx
@@ -50,8 +50,8 @@ const EntityRow = ({
     
     dispatch(getEntityUrl(entity?.id ?? 0))
       .then((url) => {
-        // window.location.assign(url);
-        window.open(url, "_blank");
+        // 直接下载文件
+        window.location.assign(url);
       })
       .finally(() => {
         setOpenLoading(false);

--- a/src/component/Admin/Entity/EntityRow.tsx
+++ b/src/component/Admin/Entity/EntityRow.tsx
@@ -51,7 +51,12 @@ const EntityRow = ({
     setOpenLoading(true);
     dispatch(getEntityUrl(entity?.id ?? 0))
       .then((url) => {
-        entityLink ? (entityLink.location.href = url) : window.open(url, "_blank");
+        if (entityLink) {
+          entityLink.close();
+          window.open(url, "_blank");
+        } else {
+          window.open(url, "_blank");
+        }
       })
       .finally(() => {
         setOpenLoading(false);

--- a/src/component/Admin/Entity/EntityRow.tsx
+++ b/src/component/Admin/Entity/EntityRow.tsx
@@ -46,23 +46,17 @@ const EntityRow = ({
 
   const onOpenClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    var entityLink = window.open("", "_blank");
-    entityLink?.document.write("Loading entity URL...");
     setOpenLoading(true);
+    
     dispatch(getEntityUrl(entity?.id ?? 0))
       .then((url) => {
-        if (entityLink) {
-          entityLink.close();
-          window.open(url, "_blank");
-        } else {
-          window.open(url, "_blank");
-        }
+        window.location.assign(url);
       })
       .finally(() => {
         setOpenLoading(false);
       })
-      .catch(() => {
-        entityLink && entityLink.close();
+      .catch((error) => {
+        console.error('Failed to get entity URL:', error);
       });
   };
 

--- a/src/component/Admin/Entity/EntityRow.tsx
+++ b/src/component/Admin/Entity/EntityRow.tsx
@@ -50,7 +50,8 @@ const EntityRow = ({
     
     dispatch(getEntityUrl(entity?.id ?? 0))
       .then((url) => {
-        window.location.assign(url);
+        // window.location.assign(url);
+        window.open(url, "_blank");
       })
       .finally(() => {
         setOpenLoading(false);

--- a/src/component/Admin/File/FileRow.tsx
+++ b/src/component/Admin/File/FileRow.tsx
@@ -72,7 +72,12 @@ const FileRow = ({
     fileLink?.document.write("Loading file URL...");
     dispatch(getFileUrl(file?.id ?? 0))
       .then((url) => {
-        fileLink ? (fileLink.location.href = url) : window.open(url, "_blank");
+        if (fileLink) {
+          fileLink.close();
+          window.open(url, "_blank");
+        } else {
+          window.open(url, "_blank");
+        }
       })
       .finally(() => {
         setOpenLoading(false);

--- a/src/component/Admin/File/FileRow.tsx
+++ b/src/component/Admin/File/FileRow.tsx
@@ -89,17 +89,8 @@ const FileRow = ({
           // 可预览文件：新窗口打开预览，窗口保持显示预览内容
           window.open(url, "_blank");
         } else {
-
-          // PlanA:
-          // 当前窗口下载（不跳转页面，直接下载链接）
-          // window.location.assign(url);
-
-          // PlanB:
-          // 在新窗口打开下载链接
-          // - 下载成功：浏览器自动关闭下载窗口
-          // - 下载失败：窗口保持打开显示错误信息
-          window.open(url, "_blank");
-
+          // 下载文件：当前窗口下载（不跳转页面，直接下载链接）
+          window.location.assign(url);
         }
       })
       .finally(() => {

--- a/src/component/Admin/File/FileRow.tsx
+++ b/src/component/Admin/File/FileRow.tsx
@@ -89,8 +89,15 @@ const FileRow = ({
           // 可预览文件：新窗口打开预览，窗口保持显示预览内容
           window.open(url, "_blank");
         } else {
-          // 下载文件：当前窗口下载（不跳转页面，直接下载链接）
-          window.location.assign(url);
+          // 下载文件：使用a标签的download属性强制下载
+          const link = document.createElement('a');
+          link.href = url;
+          link.download = file?.name || `file-${file?.id}`;
+          link.style.display = 'none';
+          
+          document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
         }
       })
       .finally(() => {


### PR DESCRIPTION
Replaced `window.open` download with `<a download>` for better compatibility.
`FileRow` now opens in viewer if available, otherwise downloads directly.

试了下是没什么问题的