### PR TITLE
feat: add alt attribute to logo image for accessibility and SEO

### DIFF
--- a/src/component/Common/Logo.tsx
+++ b/src/component/Common/Logo.tsx
@@ -28,6 +28,7 @@ const Logo = (props: any) => {
           component={"img"}
           onLoad={() => setLoaded(true)}
           src={mode === "light" ? logo : logo_light}
+          alt="Logo"
           {...props}
           sx={{
             display: loaded ? "block" : "none",


### PR DESCRIPTION
add alt attribute to logo image for accessibility and SEO
![image](https://github.com/user-attachments/assets/5eecf2cc-6c11-4ae0-ae84-f4afbc39de5e)
