### PR TITLE
[plan A] fix: new user group error in without replication

### DIFF
--- a/src/component/Admin/Group/NewGroupDIalog.tsx
+++ b/src/component/Admin/Group/NewGroupDIalog.tsx
@@ -38,8 +38,9 @@ const defaultGroup: GroupEnt = {
     redirected_source: true,
   },
   edges: {
-    storage_policies: [],
+    storage_policies: undefined,
   },
+  storage_policy_id: 1,
   id: 0,
 };
 


### PR DESCRIPTION
#270 
[cloudreve/cloudreve#2592](https://github.com/cloudreve/cloudreve/issues/2592)

Added the default storage policy (id=1), refer to backend:

```inventory/group.go:88
// Create
if group.StoragePolicyID > 0 {
	stm.SetStoragePolicyID(group.StoragePolicyID)
}
```

The logical judgment conditions for new group and update group. Maybe this should be corrected?
```inventory/group.go:103
// UpdateOne
if group.Edges.StoragePolicies != nil && group.Edges.StoragePolicies.ID > 0 {
	stm.SetStoragePolicyID(group.Edges.StoragePolicies.ID)
}
```

If feasible, refer to: #272, [cloudreve/cloudreve#2596](https://github.com/cloudreve/cloudreve/pull/2596)