### PR TITLE
fix: custom icon not draggable in file viewer

### DIFF
--- a/src/component/FileManager/Explorer/FileTypeIcon.tsx
+++ b/src/component/FileManager/Explorer/FileTypeIcon.tsx
@@ -147,6 +147,7 @@ const FileTypeIcon = ({ name, fileType, notLoaded, sx, hideUnknown, customizedCo
       //@ts-ignore
       <Box
         component={"img"}
+        draggable={false}
         sx={{
           width: "24px",
           height: "24px",


### PR DESCRIPTION
Ref: [cloudreve/cloudreve#2607](https://github.com/cloudreve/cloudreve/issues/2607)