### PR TITLE
fix(ui): the footer cannot be displayed on the public page

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,10 @@
       #app-loader .spinner .background {
         stroke: rgba(0, 0, 0, 0.1)
       }
+      #site-script-container {
+        background-color: #f5f5f5;
+        height: 5vh;
+      }
 
       @keyframes spinDash {
         0% {
@@ -114,5 +118,7 @@
       });
     </script>
   </body>
-  {siteScript}
+  <footer id="site-script-container">
+    {siteScript}
+  </footer>
 </html>

--- a/src/component/Frame/HeadlessFrame.tsx
+++ b/src/component/Frame/HeadlessFrame.tsx
@@ -31,7 +31,7 @@ const HeadlessFrame = () => {
         backgroundColor: (theme) =>
           theme.palette.mode === "light" ? theme.palette.grey[100] : theme.palette.grey[900],
         flexGrow: 1,
-        height: "100vh",
+        height: "95vh",
         overflow: "auto",
       }}
     >
@@ -42,7 +42,7 @@ const HeadlessFrame = () => {
           direction="column"
           alignItems="center"
           justifyContent="center"
-          sx={{ minHeight: "100vh" }}
+          sx={{ minHeight: "95vh" }}
         >
           <Box sx={{ width: "100%", py: 2 }}>
             <Paper


### PR DESCRIPTION
**Problem analysis**:  The UI layout of the `/session` page in v4 was changed from hard-coded `...px` to `100vh` (and `overflow-y: hidden` when width `>600px`), resulting in the custom footer part being invisible.

**Solution**: To minimize code and design structure changes, and keep the original UI centered, a hard-coded solution that reserves 5vh of footer space is adopted here, to meet the display requirements of some links（ICP备案号等）

Ref issue: [cloudreve/cloudreve#2255](https://github.com/cloudreve/cloudreve/issues/2255)

**Preview**
siteScript
```HTML
<div style="display: flex; justify-content: center; align-items: center;">
  <a href="https://beian.miit.gov.cn/" target="_blank">ICP备1号</a>
</div>
```
<img src="https://github.com/user-attachments/assets/9daf19cb-1ebe-4f3f-8aa2-244914adf2e7" width = "300" alt="preview" />
