### PR TITLE
fix(explorer): handle empty folder direct link generation error

### DIFF
--- a/src/redux/thunks/file.ts
+++ b/src/redux/thunks/file.ts
@@ -1212,6 +1212,17 @@ function startBatchGetDirectLinks(files: FileResponse[]): AppThunk<Promise<Direc
       }),
     );
 
+    // Check if there are any files to generate direct links for
+    if (allFiles.length === 0) {
+      enqueueSnackbar({
+        message: i18next.t("modals.noFileCanGenerateSourceLink"),
+        preventDuplicate: true,
+        variant: "warning",
+        action: DefaultCloseAction,
+      });
+      throw new Error("AbortError");
+    }
+
     return await dispatch(
       getFileDirectLinks({
         uris: allFiles.map((f) => getFileLinkedUri(f)),


### PR DESCRIPTION
在 `startBatchGetDirectLinks` 函数中添加了空文件检查逻辑，恢复使用了已有的本地化提醒 `noFileCanGenerateSourceLink`，该提醒之前已定义但未被使用
<table align="center">
  <tr>
    <td><img src="https://github.com/user-attachments/assets/1440c326-f730-46ad-bac5-ab20ad75f4e4" alt="图1" width="400"/></td>
    <td style="text-align: center; font-size: 48px;">➡️</td>
    <td><img src="https://github.com/user-attachments/assets/239fb85d-93d0-442e-80f4-70b1f7fd7eea" alt="图2" width="400"/></td>
  </tr>
</table>
