### PR TITLE
perf(setting): add debounce prop for logo setting preview loading optimization

### DIFF
--- a/src/component/Admin/Settings/SiteInformation/GeneralImagePreview.tsx
+++ b/src/component/Admin/Settings/SiteInformation/GeneralImagePreview.tsx
@@ -1,17 +1,28 @@
 import { Box } from "@mui/material";
-import React from "react";
+import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useTheme } from "@mui/material/styles";
 
 export interface GeneralImagePreviewProps {
   src: string;
+  debounce?: number; // (可选) 防抖时间
 }
 
-const GeneralImagePreview = ({ src }: GeneralImagePreviewProps) => {
+const GeneralImagePreview = ({ src, debounce = 0 }: GeneralImagePreviewProps) => {
   const { t } = useTranslation("dashboard");
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+
+  const [debouncedSrc, setDebouncedSrc] = useState(src);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedSrc(src);
+    }, debounce);
+
+    return () => clearTimeout(handler);
+  }, [src, debounce]);
 
   return (
     <Box sx={{ mt: isMobile ? 0 : 3 }}>
@@ -25,7 +36,7 @@ const GeneralImagePreview = ({ src }: GeneralImagePreviewProps) => {
       >
         <Box
           component={"img"}
-          src={src}
+          src={debouncedSrc}
           sx={{
             display: "block",
             maxWidth: "100%",

--- a/src/component/Admin/Settings/SiteInformation/SiteInformation.tsx
+++ b/src/component/Admin/Settings/SiteInformation/SiteInformation.tsx
@@ -144,7 +144,9 @@ const SiteInformation = () => {
               spacing={3}
               secondary={
                 <Grid item md={7} xs={12}>
-                  <GeneralImagePreview src={values.pwa_small_icon} />
+                  <Box sx={{ maxWidth: 160 }}>
+                    <GeneralImagePreview src={values.pwa_small_icon} debounce={250} />
+                  </Box>
                 </Grid>
               }
             >
@@ -164,7 +166,9 @@ const SiteInformation = () => {
               spacing={3}
               secondary={
                 <Grid item md={7} xs={12}>
-                  <GeneralImagePreview src={values.pwa_medium_icon} />
+                  <Box sx={{ maxWidth: 160 }}>
+                    <GeneralImagePreview src={values.pwa_medium_icon} debounce={250} />
+                  </Box>
                 </Grid>
               }
             >
@@ -184,7 +188,9 @@ const SiteInformation = () => {
               spacing={3}
               secondary={
                 <Grid item md={7} xs={12}>
-                  <GeneralImagePreview src={values.pwa_large_icon} />
+                  <Box sx={{ maxWidth: 160 }}>
+                    <GeneralImagePreview src={values.pwa_large_icon} debounce={250} />
+                  </Box>
                 </Grid>
               }
             >


### PR DESCRIPTION
Currently, when change of icon occurs, the preview src changes immediately.
This update introduces a debounce delay of 0.25 seconds to opt. the setting preview.