### PR TITLE
fix(i18n): add missing i18n key-value for markdown editor (#2795)

### DIFF
--- a/public/locales/en-US/markdown_editor.json
+++ b/public/locales/en-US/markdown_editor.json
@@ -10,9 +10,11 @@
     "cancel": "Cancel"
   },
   "uploadImage": {
+    "dialogTitle": "Upload image",
     "uploadInstructions": "Upload an image from your device:",
     "addViaUrlInstructions": "Or add an image from an URL:",
     "autoCompletePlaceholder": "Select or paste an image src",
+    "addViaUrlInstructionsNoUpload": "Image URL:",
     "alt": "Alt:",
     "title": "Title:"
   },

--- a/public/locales/ja-JP/markdown_editor.json
+++ b/public/locales/ja-JP/markdown_editor.json
@@ -10,9 +10,11 @@
     "cancel": "キャンセル"
   },
   "uploadImage": {
+    "dialogTitle": "画像アップロード",
     "uploadInstructions": "デバイスから画像をアップロード：",
     "addViaUrlInstructions": "またはURLから画像を追加：",
     "autoCompletePlaceholder": "画像を選択または貼り付け",
+    "addViaUrlInstructionsNoUpload": "画像URL：",
     "alt": "代替テキスト：",
     "title": "タイトル："
   },

--- a/public/locales/zh-CN/markdown_editor.json
+++ b/public/locales/zh-CN/markdown_editor.json
@@ -10,9 +10,11 @@
     "cancel": "取消"
   },
   "uploadImage": {
+    "dialogTitle": "上传图片",
     "uploadInstructions": "从您的设备中上传图片：",
     "addViaUrlInstructions": "或从网址新增图片：",
     "autoCompletePlaceholder": "选择或粘贴图片",
+    "addViaUrlInstructionsNoUpload": "图片网址：",
     "alt": "替代文本：",
     "title": "标题："
   },

--- a/public/locales/zh-TW/markdown_editor.json
+++ b/public/locales/zh-TW/markdown_editor.json
@@ -14,6 +14,7 @@
     "uploadInstructions": "從您的裝置上傳圖片：",
     "addViaUrlInstructions": "或從網址新增圖片：",
     "autoCompletePlaceholder": "選擇或貼上圖片網址",
+    "addViaUrlInstructionsNoUpload": "圖片網址：",
     "alt": "替代文字：",
     "title": "標題："
   },


### PR DESCRIPTION
Fix to [#2795](https://github.com/cloudreve/cloudreve/issues/2795).