### PR TITLE
fix(dashboard): y-axis truncated incorrectly in certain value

### DIFF
--- a/src/component/Admin/Home/Home.tsx
+++ b/src/component/Admin/Home/Home.tsx
@@ -150,7 +150,7 @@ const Home = () => {
                                 ...(summary?.metrics_summary?.files ?? []),
                                 ...(summary?.metrics_summary?.shares ?? []),
                               ];
-                              const yAxisUpperLimit = yAxisValue.length ? Math.max(...yAxisValue) : 0;
+                              const yAxisUpperLimit = yAxisValue.length ? Math.max(...yAxisValue) / 0.8 - 1 : 0;
                               const yAxisDigits = yAxisUpperLimit > 0 ? Math.floor(Math.log10(yAxisUpperLimit)) + 1 : 1;
                               return 3 + yAxisDigits * 9;
                             })()}

--- a/src/component/Admin/Home/Home.tsx
+++ b/src/component/Admin/Home/Home.tsx
@@ -151,7 +151,7 @@ const Home = () => {
                                 ...(summary?.metrics_summary?.shares ?? []),
                               ];
                               const yAxisUpperLimit = yAxisValue.length ? Math.max(...yAxisValue) / 0.8 - 1 : 0;
-                              const yAxisDigits = yAxisUpperLimit > 0 ? Math.floor(Math.log10(yAxisUpperLimit)) + 1 : 1;
+                              const yAxisDigits = yAxisUpperLimit > 1 ? Math.floor(Math.log10(yAxisUpperLimit)) + 1 : 1;
                               return 3 + yAxisDigits * 9;
                             })()}
                           />


### PR DESCRIPTION
When value in range `[81, 99]`, `[801, 999]`, `[8001, 9999]`..., the y-axis is incorrectly truncated as the advance of carry bit.

<img width="735" height="337" alt="Old" src="https://github.com/user-attachments/assets/34c9a57f-85db-4430-b628-b38a6852d04c" />

↓

<img width="733" height="345" alt="New" src="https://github.com/user-attachments/assets/f9c1c663-4bc2-402c-a182-e116f1d3de13" />
