### PR TITLE
fix(dashboard): handle empty input for min and max values (#3410, #3411)

### DIFF
--- a/src/component/Admin/FileSystem/CustomProps/EditPropsDialog.tsx
+++ b/src/component/Admin/FileSystem/CustomProps/EditPropsDialog.tsx
@@ -119,7 +119,7 @@ const EditPropsDialog = ({ open, onClose, onSave, isNew, props }: EditPropsDialo
                     <DenseFilledTextField
                       type="number"
                       value={editProps?.min || ""}
-                      onChange={(e) => setEditProps({ ...editProps, min: parseInt(e.target.value) } as CustomProps)}
+                      onChange={(e) => setEditProps({ ...editProps, min: e.target.value === "" ? undefined : parseInt(e.target.value) } as CustomProps)}
                     />
                     {fieldType.minDes && <NoMarginHelperText>{t(fieldType.minDes)}</NoMarginHelperText>}
                   </FormControl>
@@ -132,7 +132,7 @@ const EditPropsDialog = ({ open, onClose, onSave, isNew, props }: EditPropsDialo
                       type="number"
                       required={fieldType.maxRequired}
                       value={editProps?.max || ""}
-                      onChange={(e) => setEditProps({ ...editProps, max: parseInt(e.target.value) } as CustomProps)}
+                      onChange={(e) => setEditProps({ ...editProps, max: e.target.value === "" ? undefined : parseInt(e.target.value) } as CustomProps)}
                     />
                     {fieldType.maxDes && <NoMarginHelperText>{t(fieldType.maxDes)}</NoMarginHelperText>}
                   </FormControl>


### PR DESCRIPTION
Close https://github.com/cloudreve/cloudreve/issues/3410 and https://github.com/cloudreve/cloudreve/issues/3411.