### PR TITLE
feat(oidc): support nonce passthrough

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -225,6 +225,7 @@ export interface GrantService {
   redirect_uri: string;
   state: string;
   scope: string;
+  nonce?: string;
   code_challenge?: string;
   code_challenge_method?: string;
 }

--- a/src/component/Pages/Login/Authorize.tsx
+++ b/src/component/Pages/Login/Authorize.tsx
@@ -10,6 +10,7 @@ const Authorize = () => {
     redirectUri: query.get("redirect_uri") || "",
     state: query.get("state") || "",
     scope: query.get("scope") || "",
+    nonce: query.get("nonce") || undefined,
     codeChallenge: query.get("code_challenge") || undefined,
     codeChallengeMethod: query.get("code_challenge_method") || undefined,
   };

--- a/src/component/Pages/Login/Signin/SignIn.tsx
+++ b/src/component/Pages/Login/Signin/SignIn.tsx
@@ -64,6 +64,7 @@ export interface OAuthConsentProps {
   redirectUri: string;
   state: string;
   scope: string;
+  nonce?: string;
   codeChallenge?: string;
   codeChallengeMethod?: string;
 }
@@ -133,6 +134,7 @@ const EmailLogin = ({ oauthConsent }: SignInProps) => {
         redirect_uri: oauthConsent.redirectUri,
         state: oauthConsent.state,
         scope: oauthConsent.scope,
+        nonce: oauthConsent.nonce,
         code_challenge: oauthConsent.codeChallenge,
         code_challenge_method: oauthConsent.codeChallengeMethod,
       };


### PR DESCRIPTION
## Summary
- Add OIDC `nonce` passthrough in the frontend authorization flow
- Reads `nonce` from the OAuth/OIDC authorization URL
- Sends `nonce` to the backend consent API so it can be included in the ID Token

## Files
- `src/api/user.ts` - Add optional `nonce` to `GrantService`
- `src/component/Pages/Login/Authorize.tsx` - Parse `nonce` from query params
- `src/component/Pages/Login/Signin/SignIn.tsx` - Pass `nonce` through OAuth consent request

## Test plan
- [x] Authorization URL with `nonce` preserves the value through login/consent
- [x] Consent API request includes `nonce`