### PR TITLE
fix(uploader): call OBS upload callback after multipart complete

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -805,6 +805,23 @@ export function sendS3LikeCompleteUpload(policyType: string, sessionId: string, 
   };
 }
 
+export function sendObsCompleteUpload(sessionId: string, sessionKey: string): ThunkResponse {
+  return async (dispatch, _getState) => {
+    return await dispatch(
+      send(
+        `/callback/obs/${sessionId}/${sessionKey}`,
+        {
+          method: "POST",
+        },
+        {
+          ...defaultOpts,
+          bypassSnackbar: (_e) => true,
+        },
+      ),
+    );
+  };
+}
+
 export function sendOneDriveCompleteUpload(sessionId: string, sessionKey: string): ThunkResponse {
   return async (dispatch, _getState) => {
     return await dispatch(

--- a/src/component/Uploader/core/api/index.ts
+++ b/src/component/Uploader/core/api/index.ts
@@ -2,6 +2,7 @@ import { CancelToken } from "axios";
 import {
   sendCreateUploadSession,
   sendDeleteUploadSession,
+  sendObsCompleteUpload,
   sendOneDriveCompleteUpload,
   sendS3LikeCompleteUpload,
   sendUploadChunk,
@@ -375,6 +376,18 @@ export async function upyunFormUploadChunk(
 export async function s3LikeUploadCallback(sessionID: string, sessionKey: string, policyType: string): Promise<any> {
   try {
     return await store.dispatch(sendS3LikeCompleteUpload(policyType, sessionID, sessionKey));
+  } catch (e) {
+    if (e instanceof AppError) {
+      throw new S3LikeUploadCallbackError(e.response);
+    }
+
+    throw e;
+  }
+}
+
+export async function obsUploadCallback(sessionID: string, sessionKey: string): Promise<any> {
+  try {
+    return await store.dispatch(sendObsCompleteUpload(sessionID, sessionKey));
   } catch (e) {
     if (e instanceof AppError) {
       throw new S3LikeUploadCallbackError(e.response);

--- a/src/component/Uploader/core/uploader/obs.ts
+++ b/src/component/Uploader/core/uploader/obs.ts
@@ -1,5 +1,5 @@
 import Chunk, { ChunkInfo } from "./chunk";
-import { obsFinishUpload, s3LikeUploadChunk } from "../api";
+import { obsFinishUpload, obsUploadCallback, s3LikeUploadChunk } from "../api";
 import { Status } from "./base";
 
 export default class OBS extends Chunk {
@@ -19,6 +19,9 @@ export default class OBS extends Chunk {
   protected async afterUpload(): Promise<any> {
     this.logger.info(`Finishing multipart upload...`);
     this.transit(Status.finishing);
-    return obsFinishUpload(this.task.session!.completeURL, this.task.chunkProgress, this.cancelToken.token);
+    await obsFinishUpload(this.task.session!.completeURL, this.task.chunkProgress, this.cancelToken.token);
+
+    this.logger.info(`Sending OBS upload callback...`);
+    return obsUploadCallback(this.task.session!.session_id, this.task.session!.callback_secret);
   }
 }


### PR DESCRIPTION
## Summary
- add a dedicated OBS upload callback API call
- call Cloudreve's OBS callback endpoint after the client completes the OBS multipart upload
- reuse the existing upload callback error handling path

## Testing
- Not run in this repository; backend OBS package tests pass in the paired Cloudreve change.