### PR TITLE
fix(filemanager): hide more button for flattened trees (close cloudreve/cloudreve#3503)

### DIFF
--- a/src/component/FileManager/TreeView/TreeFiles.tsx
+++ b/src/component/FileManager/TreeView/TreeFiles.tsx
@@ -131,7 +131,7 @@ const TreeFiles = React.memo(
                   ))
               : shadowChild}
           </TreeFile>
-          {limit < childTreeFiles.length ? (
+          {!flatten && limit < childTreeFiles.length ? (
             <SideNavItem level={level + 1} label={t("navbar.showMore")} onClick={() => setLimit((l) => l + 50)} />
           ) : null}
         </>


### PR DESCRIPTION
Fix to https://github.com/cloudreve/cloudreve/issues/3503.